### PR TITLE
Implement ADC DMA source and wrapper

### DIFF
--- a/imxrt-hal/src/dma/peripheral.rs
+++ b/imxrt-hal/src/dma/peripheral.rs
@@ -97,6 +97,9 @@ mod private {
     impl<M> Sealed for uart::Rx<M> where M: crate::iomuxc::consts::Unsigned {}
     impl<M> Sealed for uart::Tx<M> where M: crate::iomuxc::consts::Unsigned {}
 
+    use crate::adc;
+    impl<ADCx, P> Sealed for adc::AdcSource<ADCx, P> {}
+
     use crate::spi;
     impl<M> Sealed for spi::SPI<M> where M: crate::iomuxc::consts::Unsigned {}
 }


### PR DESCRIPTION
This commit makes the ADCs a possible source for DMA operations, and creates a
user-friendly wrapper class (StreamingAdc) which can abstract the necessary
buffer wrangling.

The StreamingAdc struct may not be a good fit for this crate (after making it, it seems to be a bit niche - supporting only the interrupts-with-256-element-double-buffers case), if so that's perfectly fine and I can pull it out. I might also be able to make it more better using some subset of:
* Const generics/genericize on buffer type
* Circular buffers
* Gracefully handle overflows
* Allow operation without an interrupt handler

But, it solves _my_ usecase, today at least, and that's the only important one, right? (and I didn't want to spend too much time on it without working toward some specific goal)

Also, this PR is against the `maint-v0.4` branch, because that's what I could get `teensy4-bsp` to work with. If there's a branch of `teensy4-bsp` which works with the `master` branch of `imxrt-hal`, I can try to rebase this.
