### PR TITLE
Fix PWM driver

### DIFF
--- a/imxrt-hal/CHANGELOG.md
+++ b/imxrt-hal/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+Added calls to set pin muxing in the PWM driver. This fixes a regression in
+the PWM driver that was introduced in the 0.4 HAL release.
+
 ## [0.4.3] 2020-04-12
 
 ### Added

--- a/imxrt-hal/CHANGELOG.md
+++ b/imxrt-hal/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 ## [Unreleased]
 
+## [0.4.4] 2021-04-23
+
 ### Fixed
 
 Added calls to set pin muxing in the PWM driver. This fixes a regression in
 the PWM driver that was introduced in the 0.4 HAL release.
 
-## [0.4.3] 2020-04-12
+## [0.4.3] 2021-04-12
 
 ### Added
 
@@ -197,7 +199,8 @@ The release includes 0.3.1 fixes.
 
 Prior releases were not tracked with a changelog entry.
 
-[Unreleased]: https://github.com/imxrt-rs/imxrt-rs/compare/0.4.2...HEAD
+[Unreleased]: https://github.com/imxrt-rs/imxrt-rs/compare/0.4.4...HEAD
+[0.4.4]: https://github.com/imxrt-rs/imxrt-rs/compare/0.4.3...0.4.4
 [0.4.3]: https://github.com/imxrt-rs/imxrt-rs/compare/0.4.2...0.4.3
 [0.4.2]: https://github.com/imxrt-rs/imxrt-rs/compare/0.4.1...0.4.2
 [0.4.1]: https://github.com/imxrt-rs/imxrt-rs/compare/0.4.0...0.4.1

--- a/imxrt-hal/Cargo.toml
+++ b/imxrt-hal/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["imxrt", "nxp", "embedded", "no_std"]
 categories = ["embedded", "no-std"]
 license = "MIT/Apache-2.0"
 edition = "2018"
-version = "0.4.3"
+version = "0.4.4"
 
 [dependencies]
 as-slice = "0.1.3"

--- a/imxrt-hal/src/pwm.rs
+++ b/imxrt-hal/src/pwm.rs
@@ -166,14 +166,16 @@ macro_rules! submodule_outputs {
             pub fn outputs<A, B>(
                 self,
                 handle: &mut Handle<M>,
-                pin_a: A,
-                pin_b: B,
+                mut pin_a: A,
+                mut pin_b: B,
                 timing: Timing,
             ) -> Option<Pins<A, B>>
             where
                 A: Pin<Module = M, Submodule = $SUBMODULE, Output = pwm::A>,
                 B: Pin<Module = M, Submodule = $SUBMODULE, Output = pwm::B>,
             {
+                crate::iomuxc::pwm::prepare(&mut pin_a);
+                crate::iomuxc::pwm::prepare(&mut pin_b);
                 let clk_sel: u16 = match timing.clock_select {
                     ccm::pwm::ClockSelect::IPG(_) => ral::pwm::SMCTRL20::CLK_SEL::RW::CLK_SEL_0 as u16,
                 };


### PR DESCRIPTION
This PR fixes a regression in the PWM driver, introduced in 0.4.0.

In the 0.3 HAL, we relied on the user to set the pin alternate
settings. But after introducing the IOMUXC crate in 0.4, we made pin
muxing part of the driver's responsibility, and added calls to prepare
pins. We missed the requirement in the PWM driver. This commit
corrects the PWM driver, which has been broken since the 0.4 release.

Tested in the teensy4-rs repo. Users who are not able to adopt the
next patch release could add equivalent iomuxc calls before
constructing their PWM driver.