### PR TITLE
Add 1020 chip configuration

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,6 +55,7 @@ jobs:
       matrix:
         chips:
         - imxrt-ral/imxrt1011,imxrt1010
+        - imxrt-ral/imxrt1021,imxrt1020
         - imxrt-ral/imxrt1061,imxrt1060
         - imxrt-ral/imxrt1062,imxrt1060
         - imxrt-ral/imxrt1064,imxrt1060
@@ -130,6 +131,7 @@ jobs:
       matrix:
         chips:
         - imxrt-ral/imxrt1011,imxrt1010
+        - imxrt-ral/imxrt1021,imxrt1020
         - imxrt-ral/imxrt1062,imxrt1060
         - imxrt-ral/imxrt1176_cm7,imxrt1170
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+Add support for i.MX RT 1020 processors. Enable support with the `"imxrt1020"`
+imxrt-hal feature, and separately select your imxrt-ral feature.
+
 ## [0.5.0] 2022-01-05
 
 `imxrt-hal` provides common peripherals for all chips supported by `imxrt-ral`,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ features = ["imxrt-ral/imxrt1062", "imxrt1060"]
 [features]
 default = ["imxrt-usbd"]
 imxrt1010 = ["imxrt-iomuxc/imxrt1010"]
+imxrt1020 = ["imxrt-iomuxc/imxrt1020"]
 imxrt1060 = ["imxrt-iomuxc/imxrt1060"]
 imxrt1064 = ["imxrt-iomuxc/imxrt1060"]
 imxrt1170 = ["imxrt-iomuxc/imxrt1170"]
@@ -86,7 +87,7 @@ members = [
 
 [workspace.dependencies]
 imxrt-dma = "0.1"
-imxrt-iomuxc = "0.2"
+imxrt-iomuxc = "0.2.1"
 imxrt-hal = { version = "0.5", path = "." }
 imxrt-log = { path = "logging" }
 imxrt-ral = "0.5"

--- a/src/chip/imxrt10xx.rs
+++ b/src/chip/imxrt10xx.rs
@@ -14,6 +14,9 @@ cfg_if::cfg_if! {
     if #[cfg(chip = "imxrt1010")] {
         #[path = "imxrt10xx/imxrt1010.rs"]
         pub(crate) mod config;
+    } else if #[cfg(chip = "imxrt1020")] {
+        #[path = "imxrt10xx/imxrt1020.rs"]
+        pub(crate) mod config;
     } else if #[cfg(any(chip = "imxrt1060", chip = "imxrt1064"))] {
         #[path = "imxrt10xx/imxrt1060.rs"]
         pub(crate) mod config;

--- a/src/chip/imxrt10xx/imxrt1020.rs
+++ b/src/chip/imxrt10xx/imxrt1020.rs
@@ -1,0 +1,149 @@
+//! i.MX RT 1020 chip family features.
+//!
+//! Use this module to customize features for the
+//! 1020 chips.
+
+pub use imxrt_iomuxc::imxrt1020 as pads;
+
+#[path = "ccm"]
+pub(crate) mod ccm {
+    pub mod arm_divider;
+
+    #[path = "pre_periph_clk_pll6.rs"]
+    pub mod pre_periph_clk;
+
+    mod periph_clk2_podf;
+    mod periph_clk2_sel;
+
+    /// Peripheral clock 2.
+    pub mod periph_clk2 {
+        pub use super::periph_clk2_podf::*;
+        pub use super::periph_clk2_sel::*;
+    }
+
+    pub(crate) mod analog {
+        #[path = "pll6_500mhz.rs"]
+        pub mod pll6;
+    }
+
+    /// Re-exported by the common clock_gate module.
+    pub(crate) mod clock_gate {
+        use crate::chip::ccm::clock_gate;
+
+        /// All clock gates downstream of the PERCLK root clock.
+        pub const PERCLK_CLOCK_GATES: &[clock_gate::Locator] = &[
+            clock_gate::pit(),
+            clock_gate::gpt_bus::<1>(),
+            clock_gate::gpt_bus::<2>(),
+            clock_gate::gpt_serial::<1>(),
+            clock_gate::gpt_serial::<2>(),
+        ];
+
+        /// All clock gates downstream of the UART root clock.
+        pub const UART_CLOCK_GATES: &[clock_gate::Locator] = &[
+            clock_gate::lpuart::<1>(),
+            clock_gate::lpuart::<2>(),
+            clock_gate::lpuart::<3>(),
+            clock_gate::lpuart::<4>(),
+            clock_gate::lpuart::<5>(),
+            clock_gate::lpuart::<6>(),
+            clock_gate::lpuart::<7>(),
+            clock_gate::lpuart::<8>(),
+        ];
+
+        /// All clock gates downstream of the LPSPI root clock.
+        pub const LPSPI_CLOCK_GATES: &[clock_gate::Locator] = &[
+            clock_gate::lpspi::<1>(),
+            clock_gate::lpspi::<2>(),
+            clock_gate::lpspi::<3>(),
+            clock_gate::lpspi::<4>(),
+        ];
+
+        /// All clock gates downstream of the LPI2C root clock.
+        pub const LPI2C_CLOCK_GATES: &[clock_gate::Locator] = &[
+            clock_gate::lpi2c::<1>(),
+            clock_gate::lpi2c::<2>(),
+            clock_gate::lpi2c::<3>(),
+            clock_gate::lpi2c::<4>(),
+        ];
+
+        /// All clock gates downstream of the IPG root clock.
+        pub const IPG_CLOCK_GATES: &[clock_gate::Locator] = &[
+            clock_gate::adc::<1>(),
+            clock_gate::adc::<2>(),
+            clock_gate::dma(),
+            clock_gate::flexpwm::<1>(),
+            clock_gate::flexpwm::<2>(),
+            // GPIOs assume that we're not "fast," since the fast
+            // GPIOs run directly off the ARM / AHB clock. This
+            // is safe for now, since we don't currently support fast
+            // GPIOs.
+            clock_gate::gpio::<1>(),
+            clock_gate::gpio::<2>(),
+            clock_gate::gpio::<3>(),
+            clock_gate::gpio::<5>(),
+            clock_gate::trng(),
+            clock_gate::snvs_lp(),
+            clock_gate::snvs_hp(),
+            clock_gate::usb(),
+        ];
+    }
+
+    pub(crate) mod clko {
+        /// CLKO1 output clock selections.
+        #[repr(u32)]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub enum Clko1Selection {
+            /// PLL3 divided by 2.
+            Pll3SwClkDiv2 = 0b0000,
+            /// PLL2 divided by 2.
+            Pll2Div2 = 0b0001,
+            /// ENET PLL divided by 2.
+            EnetPllDiv2 = 0b0010,
+            /// SEMC clock root.
+            SemcClk = 0b0101,
+            /// AHB clock root.
+            AhbClk = 0b1011,
+            /// IPG clock root.
+            IpgClk = 0b1100,
+            /// PERCLK clock root.
+            Perclk = 0b1101,
+            /// PLL4 main clock root.
+            Pll4MainClk = 0b1111,
+        }
+
+        /// CLKO2 output clock selections.
+        #[repr(u32)]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        pub enum Clko2Selection {
+            /// USDHC1 clock root.
+            Usdhc1Clk = 0b00011,
+            /// LPI2C clock root.
+            Lpi2cClk = 0b00110,
+            /// Oscillator clock root.
+            OscClk = 0b01110,
+            /// LPSPI clock root.
+            LpspiClk = 0b10000,
+            /// USDHC2 clock root.
+            Usdhc2Clk = 0b10001,
+            /// SAI1 clock root.
+            Sai1Clk = 0b10010,
+            /// SAI2 clock root.
+            Sai2Clk = 0b10011,
+            /// SAI3 clock root.
+            Sai3Clk = 0b10100,
+            /// Trace clock root.
+            TraceClk = 0b10110,
+            /// CAN clock root.
+            CanClk = 0b10111,
+            /// FlexSPI clock root.
+            FlexspiClk = 0b11011,
+            /// UART clock root.
+            UartClk = 0b11100,
+            /// SPDIF0 clock root.
+            Spdif0Clk = 0b11101,
+        }
+    }
+}
+
+pub(crate) const DMA_CHANNEL_COUNT: usize = 32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@
 //! | Feature           | Description                                                      |
 //! |-------------------|------------------------------------------------------------------|
 //! | `"imxrt1010"`     | Enable features for the 1010 chips.                              |
+//! | `"imxrt1020"`     | Enable features for the 1020 chips.                              |
 //! | `"imxrt1060"`     | Enable features for the 1060 chips.                              |
 //! | `"imxrt1064"`     | Enable features for the 1064 chips.                              |
 //! | `"imxrt1170"`     | Enable features for the 1170 chips.                              |


### PR DESCRIPTION
Add chip configuration for the i.MX RT 1020 in accordance with the RM. Basic testing was done on EVK as well as an own design.

There is one TODO comment in here: In `imxrt1010.rs` `Clko2Selection` currently calls the`trace_clk_root` `TracClk` instead of `TraceClk`. I'm not sure if that is a typo or intentional. And regardless of whether it is how to spell it for 1020.