### PR TITLE
Deprecate and rename 0.5 APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ imxrt-hal feature, and separately select your imxrt-ral feature.
 _Deprecate_ the `clko2::Selection::TracClk` item. Prefer the correctly-spelled
 variant, `clko2::Selection::TraceClk`.
 
+_Deprecate_ the following items in the `timer` module:
+
+- `timer::BlockingPitChan` and constructor `from_pit_channel`.
+- `timer::RawCountDownPitChan`and constructor `from_pit_channel`.
+
+The type names differ from `*PitChain` by one letter. Prefer the spellings
+without `*Chan` and `*_channel`.
+
 ## [0.5.0] 2022-01-05
 
 `imxrt-hal` provides common peripherals for all chips supported by `imxrt-ral`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 Add support for i.MX RT 1020 processors. Enable support with the `"imxrt1020"`
 imxrt-hal feature, and separately select your imxrt-ral feature.
 
+_Deprecate_ the `clko2::Selection::TracClk` item. Prefer the correctly-spelled
+variant, `clko2::Selection::TraceClk`.
+
 ## [0.5.0] 2022-01-05
 
 `imxrt-hal` provides common peripherals for all chips supported by `imxrt-ral`,

--- a/board/src/imxrt1010evk.rs
+++ b/board/src/imxrt1010evk.rs
@@ -320,7 +320,7 @@ pub mod clock_out {
         Clko2::LpspiClk,
         Clko2::Sai1Clk,
         Clko2::Sai3Clk,
-        Clko2::TracClk,
+        Clko2::TraceClk,
         Clko2::FlexspiClk,
         Clko2::UartClk,
         Clko2::Spdif0Clk,

--- a/examples/rtic_gpio_input.rs
+++ b/examples/rtic_gpio_input.rs
@@ -9,7 +9,7 @@
 
 #[rtic::app(device = board, peripherals = false)]
 mod app {
-    use hal::{gpio::Trigger, timer::BlockingPitChan};
+    use hal::{gpio::Trigger, timer::BlockingPit};
     use imxrt_hal as hal;
 
     #[shared]
@@ -19,7 +19,7 @@ mod app {
     struct Local {
         led: board::Led,
         button: board::Button,
-        delay: BlockingPitChan<2, { board::PIT_FREQUENCY }>,
+        delay: BlockingPit<2, { board::PIT_FREQUENCY }>,
     }
 
     #[init]
@@ -37,7 +37,7 @@ mod app {
             },
         ) = board::new();
         led.set();
-        let delay = BlockingPitChan::from_pit_channel(pit);
+        let delay = BlockingPit::from_pit(pit);
         let button_port = ports.button_mut();
         button_port.set_interrupt(&button, Some(Trigger::FallingEdge));
         (Shared {}, Local { led, button, delay }, init::Monotonics())

--- a/src/chip/imxrt10xx/imxrt1010.rs
+++ b/src/chip/imxrt10xx/imxrt1010.rs
@@ -109,13 +109,25 @@ pub(crate) mod ccm {
             /// SAI3 clock root.
             Sai3Clk = 0b10100,
             /// Trace clock root.
-            TracClk = 0b10110,
+            TraceClk = 0b10110,
             /// FlexSPI clock root.
             FlexspiClk = 0b11011,
             /// UART clock root.
             UartClk = 0b11100,
             /// SPDIF0 clock root.
             Spdif0Clk = 0b11101,
+        }
+
+        impl Clko2Selection {
+            /// Trace clock root.
+            ///
+            /// Prefer [`TraceClk`](Self::TraceClk), which is correctly spelled.
+            #[deprecated(
+                since = "0.5.1",
+                note = "Use the correctly-spelled 'TraceClk' variant."
+            )]
+            #[allow(non_upper_case_globals)]
+            pub const TracClk: Clko2Selection = Clko2Selection::TraceClk;
         }
     }
 }

--- a/src/common/timer.rs
+++ b/src/common/timer.rs
@@ -186,7 +186,7 @@ impl<const HZ: u32> TimerDurationExt for fugit::TimerDurationU64<HZ> {
 ///
 /// use hal::{
 ///     ccm::{self, clock_gate, perclk_clk},
-///     timer::BlockingPitChan,
+///     timer::BlockingPit,
 /// };
 ///
 /// let mut ccm = unsafe { ral::ccm::CCM::instance() };
@@ -210,7 +210,7 @@ impl<const HZ: u32> TimerDurationExt for fugit::TimerDurationU64<HZ> {
 /// let pit = unsafe { ral::pit::PIT::instance() };
 /// let (pit0, _, _, _) = hal::pit::new(pit);
 ///
-/// let mut blocking = BlockingPitChan::<0, PIT_FREQUENCY_HZ>::from_pit_channel(pit0);
+/// let mut blocking = BlockingPit::<0, PIT_FREQUENCY_HZ>::from_pit(pit0);
 /// // Block for milliseconds:
 /// blocking.block_ms(1000);
 /// // Block for microseconds:
@@ -265,7 +265,7 @@ where
     /// ```compile_fail
     /// // See struct-level documentation for configuration...
     /// # let pit0 = unsafe { imxrt_hal::pit::Pit::<0>::new(&imxrt_ral::pit::PIT::instance()) };
-    /// # let mut blocking = imxrt_hal::timer::BlockingPitChan::<0, PIT_FREQUENCY_HZ>::from_pit_channel(pit0);
+    /// # let mut blocking = imxrt_hal::timer::BlockingPit::<0, PIT_FREQUENCY_HZ>::from_pit(pit0);
     /// # const PIT_FREQUENCY_HZ: u32 = 75000000;
     /// // 99 seconds, expressed in microseconds, cannot fit within a u32 counter
     /// // that counts at PIT_FREQUENCY_HZ. This fails to compile:
@@ -276,7 +276,7 @@ where
     ///
     /// ```no_run
     /// # let pit0 = unsafe { imxrt_hal::pit::Pit::<0>::new(&imxrt_ral::pit::PIT::instance()) };
-    /// # let mut blocking = imxrt_hal::timer::BlockingPitChan::<0, PIT_FREQUENCY_HZ>::from_pit_channel(pit0);
+    /// # let mut blocking = imxrt_hal::timer::BlockingPit::<0, PIT_FREQUENCY_HZ>::from_pit(pit0);
     /// # const PIT_FREQUENCY_HZ: u32 = 75000000;
     /// // However, 99 milliseconds, expressed in microseconds, can fit within a u32
     /// // counter that counts at PIT_FREQENCY_HZ.
@@ -346,7 +346,7 @@ where
 
 /// Prepares a PIT channel to be adapted by blocking / count down
 /// adapters.
-fn prepare_pit_channel<const N: u8>(pit: &mut pit::Pit<N>) {
+fn prepare_pit<const N: u8>(pit: &mut pit::Pit<N>) {
     pit.disable();
     pit.clear_elapsed();
     pit.set_chained(false);
@@ -381,13 +381,30 @@ fn prepare_gpt<const N: u8>(gpt: &mut gpt::Gpt<N>) {
 }
 
 /// A single PIT channel that acts as a blocking timer.
-pub type BlockingPitChan<const N: u8, const HZ: u32> = Blocking<pit::Pit<N>, HZ>;
+pub type BlockingPit<const N: u8, const HZ: u32> = Blocking<pit::Pit<N>, HZ>;
 
-impl<const N: u8, const HZ: u32> BlockingPitChan<N, HZ> {
+/// A single PIT channel that acts as a blocking timer.
+///
+/// Prefer [`BlockingPit`], which is easier to type. It is also more
+/// distinct than [`BlockingPitChain`], which varies from `BlockingPitChan`
+/// by only one letter.
+#[deprecated(since = "0.5.1", note = "Use BlockingPit")]
+pub type BlockingPitChan<const N: u8, const HZ: u32> = BlockingPit<N, HZ>;
+
+impl<const N: u8, const HZ: u32> BlockingPit<N, HZ> {
     /// Create a blocking adapter from a PIT channel.
-    pub fn from_pit_channel(mut pit: pit::Pit<N>) -> Self {
-        prepare_pit_channel(&mut pit);
+    pub fn from_pit(mut pit: pit::Pit<N>) -> Self {
+        prepare_pit(&mut pit);
         Self::new(pit)
+    }
+
+    /// Create a blocking adapter from a PIT channel.
+    ///
+    /// Prefer [`from_pit`](Self::from_pit), which is easier to type
+    /// and matches the name of the type we're converting.
+    #[deprecated(since = "0.5.1", note = "Use from_pit")]
+    pub fn from_pit_channel(pit: pit::Pit<N>) -> Self {
+        Self::from_pit(pit)
     }
 }
 
@@ -510,13 +527,30 @@ where
 }
 
 /// A count down timer over a PIT channel.
-pub type RawCountDownPitChan<const N: u8> = RawCountDown<pit::Pit<N>>;
+pub type RawCountDownPit<const N: u8> = RawCountDown<pit::Pit<N>>;
 
-impl<const N: u8> RawCountDownPitChan<N> {
+/// A count down timer over a PIT channel.
+///
+/// Prefer [`RawCountDownPit`], which is easier to type. It is also more
+/// distinct than [`RawCountDownPitChain`], which varies from `RawCountDownPitChan`
+/// by only one letter.
+#[deprecated(since = "0.5.1", note = "Use RawCountDownPit")]
+pub type RawCountDownPitChan<const N: u8> = RawCountDownPit<N>;
+
+impl<const N: u8> RawCountDownPit<N> {
     /// Create a count down timer from a PIT channel.
-    pub fn from_pit_channel(mut pit: pit::Pit<N>) -> Self {
-        prepare_pit_channel(&mut pit);
+    pub fn from_pit(mut pit: pit::Pit<N>) -> Self {
+        prepare_pit(&mut pit);
         Self::new(pit)
+    }
+
+    /// Create a count down timer from a PIT channel.
+    ///
+    /// Prefer [`from_pit`](Self::from_pit), which is easier to type
+    /// and matches the name of the type we're converting.
+    #[deprecated(since = "0.5.1", note = "Use from_pit")]
+    pub fn from_pit_channel(pit: pit::Pit<N>) -> Self {
+        Self::from_pit(pit)
     }
 }
 

--- a/tests/1010_trace_clk_rename.rs
+++ b/tests/1010_trace_clk_rename.rs
@@ -1,0 +1,15 @@
+//! Tests backwards compatibility of a typo correction.
+
+#![cfg(chip = "imxrt1010")]
+#![allow(deprecated)]
+
+use hal::ccm::output_source::clko2::Selection;
+use imxrt_hal as hal;
+
+const USER_CONSTANT: Selection = Selection::TracClk;
+
+#[test]
+fn trace_clk_match() {
+    assert!(matches!(USER_CONSTANT, Selection::TracClk));
+    assert!(matches!(USER_CONSTANT, Selection::TraceClk));
+}


### PR DESCRIPTION
The PR fixes typos in the public API, and rename select `timer` types and methods. We maintain the misspelled / original APIs with deprecation warnings. See the individual commit messages for details.

I plan to release this in the 0.5 series. If accepted, I'll float the breaking removal commit(s) in a separate branch, and merge them once there's a more interesting breaking change to release.