### PR TITLE
Read the OUT endpoint in the USB device logger

### DIFF
--- a/logging/CHANGELOG.md
+++ b/logging/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+Read the bulk OUT endpoint in the USB device logger. This resolves some poor
+behaviors observed with Linux hosts.
+
 ## [0.1.0] 2022-01-05
 
 First release. See the README and API documentation for the baseline features.

--- a/logging/src/usbd.rs
+++ b/logging/src/usbd.rs
@@ -105,6 +105,11 @@ unsafe fn poll() {
         CONFIGURED = true;
     }
 
+    // If the host sends us data, pretend to read it.
+    // This prevents us from continuously NAKing the host,
+    // which the host might not appreciate.
+    class.read_packet(&mut []).ok();
+
     // There's no need to wait if we were are newly configured.
     if check_consumer {
         let consumer = CONSUMER.assume_init_mut();


### PR DESCRIPTION
If we don't read data that the hosts sends us, we buffer the data and NAK the host.  The host might not like that. This commit resolves USB device logging issues observed on a Linux host. See here [1] for the troubleshooting and discussions.

[1]: https://github.com/mciantyre/teensy4-rs/discussions/132

Just by attempting to read, we mark the transfer as complete on our end. The driver doesn't attempt to copy anything, and it'll effectively discard the data by scheduling another transfer over whatever we received.