### PR TITLE
Port imxrt-usbd examples for cross-board USB testing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -100,7 +100,7 @@ jobs:
           --example=hal_clock_out
           --example=hal_pwm --example=rtic_pwm
           --example=hal_i2c_mpu9250 --example=hal_i2c_lcd1602
-          --example=rtic_usb_serial
+          --example=rtic_usb_serial --example=rtic_usb_test_class
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -100,6 +100,7 @@ jobs:
           --example=hal_clock_out
           --example=hal_pwm --example=rtic_pwm
           --example=hal_i2c_mpu9250 --example=hal_i2c_lcd1602
+          --example=rtic_usb_serial
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -100,7 +100,7 @@ jobs:
           --example=hal_clock_out
           --example=hal_pwm --example=rtic_pwm
           --example=hal_i2c_mpu9250 --example=hal_i2c_lcd1602
-          --example=rtic_usb_serial --example=rtic_usb_test_class
+          --example=rtic_usb_serial --example=rtic_usb_test_class --example=rtic_usb_keypress --example=rtic_usb_mouse
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ panic = "abort"
 opt-level = "z"
 lto = "fat"
 panic = "abort"
+overflow-checks = true
 
 [profile.dev.build-override]
 opt-level = 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ cortex-m-rtic = "1.0"
 log = "0.4"
 defmt = "0.3"
 pin-utils = "0.1"
-usb-device = "0.2"
+usb-device = { version = "0.2", features = ["test-class-high-speed"] }
 usbd-serial = "0.1"
 
 [target.'cfg(all(target_arch = "arm", target_os = "none"))'.dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ defmt = "0.3"
 pin-utils = "0.1"
 usb-device = { version = "0.2", features = ["test-class-high-speed"] }
 usbd-serial = "0.1"
+usbd-hid = "0.6"
 
 [target.'cfg(all(target_arch = "arm", target_os = "none"))'.dev-dependencies]
 board = { path = "board" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,8 @@ cortex-m-rtic = "1.0"
 log = "0.4"
 defmt = "0.3"
 pin-utils = "0.1"
+usb-device = "0.2"
+usbd-serial = "0.1"
 
 [target.'cfg(all(target_arch = "arm", target_os = "none"))'.dev-dependencies]
 board = { path = "board" }

--- a/board/build.rs
+++ b/board/build.rs
@@ -28,7 +28,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             "imxrt1010evk" => {
                 RuntimeBuilder::from_flexspi(Family::Imxrt1010, 16 * 1024 * 1024)
-                    .rodata(Memory::Dtcm)
+                    .flexram_banks(imxrt_rt::FlexRamBanks {
+                        ocram: 1,
+                        itcm: 1,
+                        dtcm: 2,
+                    })
+                    .bss(Memory::Dtcm)
+                    .data(Memory::Dtcm)
+                    .uninit(Memory::Dtcm)
                     .build()?;
                 println!("cargo:rustc-cfg=board=\"imxrt1010evk\"");
                 println!("cargo:rustc-cfg=chip=\"imxrt1010\"");

--- a/board/build.rs
+++ b/board/build.rs
@@ -21,6 +21,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "teensy4" => {
                 RuntimeBuilder::from_flexspi(Family::Imxrt1060, 1984 * 1024)
                     .rodata(Memory::Dtcm)
+                    .stack_size(32 * 1024)
                     .build()?;
                 println!("cargo:rustc-cfg=board=\"teensy4\"");
                 println!("cargo:rustc-cfg=chip=\"imxrt1060\"");
@@ -44,6 +45,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "imxrt1060evk" => {
                 RuntimeBuilder::from_flexspi(Family::Imxrt1060, 8 * 1024 * 1024)
                     .rodata(Memory::Dtcm)
+                    .stack_size(32 * 1024)
                     .build()?;
                 println!("cargo:rustc-cfg=board=\"imxrt1060evk\"");
                 println!("cargo:rustc-cfg=chip=\"imxrt1060\"");
@@ -57,6 +59,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     16 * 1024 * 1024,
                 )
                 .rodata(imxrt_rt::Memory::Dtcm)
+                .stack_size(32 * 1024)
                 .build()?;
                 println!("cargo:rustc-cfg=board=\"imxrt1170evk-cm7\"");
                 println!("cargo:rustc-cfg=chip=\"imxrt1170\"");

--- a/board/src/lib.rs
+++ b/board/src/lib.rs
@@ -337,4 +337,27 @@ pub mod logging {
             }
         }
     }
+
+    /// Initialize the LPUART logger.
+    ///
+    /// Useful when you're debugging USB devices, and you want to get
+    /// log messages out of the device some other way.
+    ///
+    /// This always enables interrupts. If you don't want interrupts to active,
+    /// then don't unmask them.
+    pub fn lpuart<P, const LPUART: u8>(
+        frontend: Frontend,
+        lpuart: Lpuart<P, LPUART>,
+        dma_channel: Channel,
+    ) -> imxrt_log::Poller {
+        match frontend {
+            Frontend::Log => {
+                imxrt_log::log::lpuart(lpuart, dma_channel, imxrt_log::Interrupts::Enabled).unwrap()
+            }
+            Frontend::Defmt => {
+                imxrt_log::defmt::lpuart(lpuart, dma_channel, imxrt_log::Interrupts::Enabled)
+                    .unwrap()
+            }
+        }
+    }
 }

--- a/examples/rtic_usb_keypress.rs
+++ b/examples/rtic_usb_keypress.rs
@@ -1,0 +1,209 @@
+//! Demonstrates a USB keypress using RTIC.
+//!
+//! Flash your board with this example. Your device will occasionally
+//! send some kind of keypress to your host.
+
+#![no_std]
+#![no_main]
+
+#[rtic::app(device = board, peripherals = false)]
+mod app {
+    use hal::usbd::{BusAdapter, EndpointMemory, EndpointState, Speed};
+    use imxrt_hal as hal;
+
+    use usb_device::{
+        bus::UsbBusAllocator,
+        device::{UsbDevice, UsbDeviceBuilder, UsbDeviceState, UsbVidPid},
+    };
+    use usbd_hid::{
+        descriptor::{KeyboardReport, SerializedDescriptor as _},
+        hid_class::HIDClass,
+    };
+
+    /// Change me if you want to play with a full-speed USB device.
+    const SPEED: Speed = Speed::High;
+    /// Matches whatever is in imxrt-log.
+    const VID_PID: UsbVidPid = UsbVidPid(0x5824, 0x27dd);
+    const PRODUCT: &str = "imxrt-hal-example";
+    /// How frequently should we poll the logger?
+    const LPUART_POLL_INTERVAL_MS: u32 = board::PIT_FREQUENCY / 1_000 * 100;
+    /// Change me to change how log messages are serialized.
+    ///
+    /// If changing to `Defmt`, you'll need to update the logging macros in
+    /// this example. You'll also need to make sure the USB device you're debugging
+    /// uses `defmt`.
+    const FRONTEND: board::logging::Frontend = board::logging::Frontend::Log;
+    /// The USB GPT timer we use to (infrequently) send mouse updates.
+    const GPT_INSTANCE: imxrt_usbd::gpt::Instance = imxrt_usbd::gpt::Instance::Gpt0;
+    /// How frequently should we push mouse updates to the host?
+    const MOUSE_UPDATE_INTERVAL_MS: u32 = 200;
+
+    /// This allocation is shared across all USB endpoints. It needs to be large
+    /// enough to hold the maximum packet size for *all* endpoints. If you start
+    /// noticing panics, check to make sure that this is large enough for all endpoints.
+    static EP_MEMORY: EndpointMemory<1024> = EndpointMemory::new();
+    /// This manages the endpoints. It's large enough to hold the maximum number
+    /// of endpoints; we're not using all the endpoints in this example.
+    static EP_STATE: EndpointState = EndpointState::max_endpoints();
+
+    use core::{iter::Cycle, slice::Iter};
+    type MessageIter = Cycle<Iter<'static, u8>>;
+    const MESSAGE: &[u8] = b"Ia! Ia! Cthulhu fhtagn!  ";
+
+    type Bus = BusAdapter;
+
+    #[local]
+    struct Local {
+        class: HIDClass<'static, Bus>,
+        device: UsbDevice<'static, Bus>,
+        led: board::Led,
+        poller: board::logging::Poller,
+        timer: hal::pit::Pit<0>,
+        message: MessageIter,
+    }
+
+    #[shared]
+    struct Shared {}
+
+    #[init(local = [bus: Option<UsbBusAllocator<Bus>> = None])]
+    fn init(ctx: init::Context) -> (Shared, Local, init::Monotonics) {
+        let (
+            board::Common {
+                pit: (mut timer, _, _, _),
+                usb1,
+                usbnc1,
+                usbphy1,
+                mut dma,
+                ..
+            },
+            board::Specifics { led, console, .. },
+        ) = board::new();
+        timer.set_load_timer_value(LPUART_POLL_INTERVAL_MS);
+        timer.set_interrupt_enable(true);
+        timer.enable();
+
+        let dma_a = dma[board::BOARD_DMA_A_INDEX].take().unwrap();
+        let poller = board::logging::lpuart(FRONTEND, console, dma_a);
+
+        let usbd = hal::usbd::Instances {
+            usb: usb1,
+            usbnc: usbnc1,
+            usbphy: usbphy1,
+        };
+
+        let bus = BusAdapter::with_speed(usbd, &EP_MEMORY, &EP_STATE, SPEED);
+        bus.set_interrupts(true);
+        bus.gpt_mut(GPT_INSTANCE, |gpt| {
+            gpt.stop();
+            gpt.clear_elapsed();
+            gpt.set_interrupt_enabled(true);
+            gpt.set_mode(imxrt_usbd::gpt::Mode::Repeat);
+            gpt.set_load(MOUSE_UPDATE_INTERVAL_MS * 1000);
+            gpt.reset();
+            gpt.run();
+        });
+
+        let bus = ctx.local.bus.insert(UsbBusAllocator::new(bus));
+        // Note that "4" correlates to a 1ms polling interval. Since this is a high speed
+        // device, bInterval is computed differently.
+        let class = HIDClass::new(bus, KeyboardReport::desc(), 4);
+        let device = UsbDeviceBuilder::new(bus, VID_PID)
+            .product(PRODUCT)
+            .device_class(usbd_serial::USB_CLASS_CDC)
+            .max_packet_size_0(64)
+            .build();
+
+        (
+            Shared {},
+            Local {
+                class,
+                device,
+                led,
+                poller,
+                timer,
+                message: MESSAGE.iter().cycle(),
+            },
+            init::Monotonics(),
+        )
+    }
+
+    #[task(binds = BOARD_PIT, local = [poller, timer], priority = 1)]
+    fn pit_interrupt(ctx: pit_interrupt::Context) {
+        while ctx.local.timer.is_elapsed() {
+            ctx.local.timer.clear_elapsed();
+        }
+
+        ctx.local.poller.poll();
+    }
+
+    #[task(binds = BOARD_USB1, local = [device, class, led, message, configured: bool = false], priority = 2)]
+    fn usb1(ctx: usb1::Context) {
+        let usb1::LocalResources {
+            class,
+            device,
+            led,
+            configured,
+            message,
+        } = ctx.local;
+
+        device.poll(&mut [class]);
+
+        if device.state() == UsbDeviceState::Configured {
+            if !*configured {
+                device.bus().configure();
+            }
+            *configured = true;
+        } else {
+            *configured = false;
+        }
+
+        if *configured {
+            let elapsed = device.bus().gpt_mut(GPT_INSTANCE, |gpt| {
+                let elapsed = gpt.is_elapsed();
+                while gpt.is_elapsed() {
+                    gpt.clear_elapsed();
+                }
+                elapsed
+            });
+
+            if elapsed {
+                led.toggle();
+                let code = *message.next().unwrap();
+                if let Some(report) = translate_char(code) {
+                    class.push_input(&report).ok();
+                }
+            }
+        }
+    }
+
+    fn translate_char(ch: u8) -> Option<KeyboardReport> {
+        fn simple_kr(modifier: u8, keycodes: [u8; 6]) -> Option<KeyboardReport> {
+            Some(KeyboardReport {
+                modifier,
+                reserved: 0,
+                leds: 0,
+                keycodes,
+            })
+        }
+
+        match ch {
+            b'a'..=b'z' => {
+                let code = ch - b'a' + 4;
+                simple_kr(0, [code, 0, 0, 0, 0, 0])
+            }
+            b'A'..=b'Z' => {
+                let code = ch - b'A' + 4;
+                simple_kr(2, [code, 0, 0, 0, 0, 0])
+            }
+            b'!'..=b')' => {
+                let code = ch - b'!' + 0x1e;
+                simple_kr(2, [code, 0, 0, 0, 0, 0])
+            }
+            b' ' => simple_kr(0, [0x2c, 0, 0, 0, 0, 0]),
+            _ => {
+                log::error!("Unsupported character '{}'", ch);
+                None
+            }
+        }
+    }
+}

--- a/examples/rtic_usb_mouse.rs
+++ b/examples/rtic_usb_mouse.rs
@@ -1,0 +1,176 @@
+//! Demonstrates a USB mouse using RTIC.
+//!
+//! Flash your board with this example. You should observe your mouse slowly
+//! inching in one direction every time the LED blinks.
+
+#![no_std]
+#![no_main]
+
+#[rtic::app(device = board, peripherals = false)]
+mod app {
+    use hal::usbd::{BusAdapter, EndpointMemory, EndpointState, Speed};
+    use imxrt_hal as hal;
+
+    use usb_device::{
+        bus::UsbBusAllocator,
+        device::{UsbDevice, UsbDeviceBuilder, UsbDeviceState, UsbVidPid},
+    };
+    use usbd_hid::{
+        descriptor::{MouseReport, SerializedDescriptor as _},
+        hid_class::HIDClass,
+    };
+
+    /// Change me if you want to play with a full-speed USB device.
+    const SPEED: Speed = Speed::High;
+    /// Matches whatever is in imxrt-log.
+    const VID_PID: UsbVidPid = UsbVidPid(0x5824, 0x27dd);
+    const PRODUCT: &str = "imxrt-hal-example";
+    /// How frequently should we poll the logger?
+    const LPUART_POLL_INTERVAL_MS: u32 = board::PIT_FREQUENCY / 1_000 * 100;
+    /// Change me to change how log messages are serialized.
+    ///
+    /// If changing to `Defmt`, you'll need to update the logging macros in
+    /// this example. You'll also need to make sure the USB device you're debugging
+    /// uses `defmt`.
+    const FRONTEND: board::logging::Frontend = board::logging::Frontend::Log;
+    /// The USB GPT timer we use to (infrequently) send mouse updates.
+    const GPT_INSTANCE: imxrt_usbd::gpt::Instance = imxrt_usbd::gpt::Instance::Gpt0;
+    /// How frequently should we push mouse updates to the host?
+    const MOUSE_UPDATE_INTERVAL_MS: u32 = 200;
+
+    /// This allocation is shared across all USB endpoints. It needs to be large
+    /// enough to hold the maximum packet size for *all* endpoints. If you start
+    /// noticing panics, check to make sure that this is large enough for all endpoints.
+    static EP_MEMORY: EndpointMemory<1024> = EndpointMemory::new();
+    /// This manages the endpoints. It's large enough to hold the maximum number
+    /// of endpoints; we're not using all the endpoints in this example.
+    static EP_STATE: EndpointState = EndpointState::max_endpoints();
+
+    type Bus = BusAdapter;
+
+    #[local]
+    struct Local {
+        class: HIDClass<'static, Bus>,
+        device: UsbDevice<'static, Bus>,
+        led: board::Led,
+        poller: board::logging::Poller,
+        timer: hal::pit::Pit<0>,
+    }
+
+    #[shared]
+    struct Shared {}
+
+    #[init(local = [bus: Option<UsbBusAllocator<Bus>> = None])]
+    fn init(ctx: init::Context) -> (Shared, Local, init::Monotonics) {
+        let (
+            board::Common {
+                pit: (mut timer, _, _, _),
+                usb1,
+                usbnc1,
+                usbphy1,
+                mut dma,
+                ..
+            },
+            board::Specifics { led, console, .. },
+        ) = board::new();
+        timer.set_load_timer_value(LPUART_POLL_INTERVAL_MS);
+        timer.set_interrupt_enable(true);
+        timer.enable();
+
+        let dma_a = dma[board::BOARD_DMA_A_INDEX].take().unwrap();
+        let poller = board::logging::lpuart(FRONTEND, console, dma_a);
+
+        let usbd = hal::usbd::Instances {
+            usb: usb1,
+            usbnc: usbnc1,
+            usbphy: usbphy1,
+        };
+
+        let bus = BusAdapter::with_speed(usbd, &EP_MEMORY, &EP_STATE, SPEED);
+        bus.set_interrupts(true);
+        bus.gpt_mut(GPT_INSTANCE, |gpt| {
+            gpt.stop();
+            gpt.clear_elapsed();
+            gpt.set_interrupt_enabled(true);
+            gpt.set_mode(imxrt_usbd::gpt::Mode::Repeat);
+            gpt.set_load(MOUSE_UPDATE_INTERVAL_MS * 1000);
+            gpt.reset();
+            gpt.run();
+        });
+
+        let bus = ctx.local.bus.insert(UsbBusAllocator::new(bus));
+        // Note that "4" correlates to a 1ms polling interval. Since this is a high speed
+        // device, bInterval is computed differently.
+        let class = HIDClass::new(bus, MouseReport::desc(), 4);
+        let device = UsbDeviceBuilder::new(bus, VID_PID)
+            .product(PRODUCT)
+            .device_class(usbd_serial::USB_CLASS_CDC)
+            .max_packet_size_0(64)
+            .build();
+
+        (
+            Shared {},
+            Local {
+                class,
+                device,
+                led,
+                poller,
+                timer,
+            },
+            init::Monotonics(),
+        )
+    }
+
+    #[task(binds = BOARD_PIT, local = [poller, timer], priority = 1)]
+    fn pit_interrupt(ctx: pit_interrupt::Context) {
+        while ctx.local.timer.is_elapsed() {
+            ctx.local.timer.clear_elapsed();
+        }
+
+        ctx.local.poller.poll();
+    }
+
+    #[task(binds = BOARD_USB1, local = [device, class, led, configured: bool = false], priority = 2)]
+    fn usb1(ctx: usb1::Context) {
+        let usb1::LocalResources {
+            class,
+            device,
+            led,
+            configured,
+        } = ctx.local;
+
+        device.poll(&mut [class]);
+
+        if device.state() == UsbDeviceState::Configured {
+            if !*configured {
+                device.bus().configure();
+            }
+            *configured = true;
+        } else {
+            *configured = false;
+        }
+
+        if *configured {
+            let elapsed = device.bus().gpt_mut(GPT_INSTANCE, |gpt| {
+                let elapsed = gpt.is_elapsed();
+                while gpt.is_elapsed() {
+                    gpt.clear_elapsed();
+                }
+                elapsed
+            });
+
+            if elapsed {
+                led.toggle();
+                class
+                    .push_input(&MouseReport {
+                        buttons: 0,
+                        x: 4,
+                        y: 4,
+                        wheel: 0,
+                        pan: 0,
+                    })
+                    .ok();
+            }
+        }
+    }
+}

--- a/examples/rtic_usb_serial.rs
+++ b/examples/rtic_usb_serial.rs
@@ -1,0 +1,169 @@
+//! Demonstrates a USB serial device in RTIC.
+//!
+//! Flash your board with this example. Then, connect a serial interface to the USB device.
+//! You should see all inputs echoed back to you. Every loopback toggles the LED.
+//!
+//! The USB peripheral varies by board. If there's more than one port on your board, check
+//! you board's documentation to understand which port is used here.
+//!
+//! This example may not work on Windows. Read below for more information.
+//!
+//! # Known issues
+//!
+//! `usbd_serial::SerialPort` always allocates a bulk endpoint max packet size of 64 bytes. But
+//! when the USB bus is configured for high speed operation, your host may warn about this not being
+//! compliant. As of this writing, we cannot configure the `usbd_serial::SerialPort` object, so
+//! we're ignoring these warnings (even if that means this example doesn't work on your host).
+//! A workaround is to use `usbd_serial::CdcAcmClass` directly; we can configure the max packet size
+//! in this API. But, that adds complexity to the example.
+//!
+//! Similarly, `usbd_serial::CdcAcmClass` believes `bInterval` for the interrupt endpoint should
+//! be 255 (ms). This is invalid for high speed operation. We're again ignoring any host warnings
+//! for this condition. There is no known workaround besides a patch.
+//!
+//! I think both of these could be fixed in a backwards-compatible manner in the upstream project.
+
+#![no_std]
+#![no_main]
+
+#[rtic::app(device = board, peripherals = false)]
+mod app {
+    use hal::usbd::{BusAdapter, EndpointMemory, EndpointState, Speed};
+    use imxrt_hal as hal;
+
+    use usb_device::{
+        bus::UsbBusAllocator,
+        device::{UsbDevice, UsbDeviceBuilder, UsbDeviceState, UsbVidPid},
+    };
+    use usbd_serial::SerialPort;
+
+    /// Change me if you want to play with a full-speed USB device.
+    const SPEED: Speed = Speed::High;
+    /// Matches whatever is in imxrt-log.
+    const VID_PID: UsbVidPid = UsbVidPid(0x5824, 0x27dd);
+    const PRODUCT: &str = "imxrt-hal-example";
+    /// How frequently should we poll the logger?
+    const LPUART_POLL_INTERVAL_MS: u32 = board::PIT_FREQUENCY / 1_000 * 100;
+    /// Change me to change how log messages are serialized.
+    ///
+    /// If changing to `Defmt`, you'll need to update the logging macros in
+    /// this example. You'll also need to make sure the USB device you're debugging
+    /// uses `defmt`.
+    const FRONTEND: board::logging::Frontend = board::logging::Frontend::Log;
+
+    /// This allocation is shared across all USB endpoints. It needs to be large
+    /// enough to hold the maximum packet size for *all* endpoints. If you start
+    /// noticing panics, check to make sure that this is large enough for all endpoints.
+    static EP_MEMORY: EndpointMemory<2048> = EndpointMemory::new();
+    /// This manages the endpoints. It's large enough to hold the maximum number
+    /// of endpoints; we're not using all the endpoints in this example.
+    static EP_STATE: EndpointState = EndpointState::max_endpoints();
+
+    type Bus = BusAdapter;
+
+    #[local]
+    struct Local {
+        class: SerialPort<'static, Bus>,
+        device: UsbDevice<'static, Bus>,
+        led: board::Led,
+        poller: board::logging::Poller,
+        timer: hal::pit::Pit<0>,
+    }
+
+    #[shared]
+    struct Shared {}
+
+    #[init(local = [bus: Option<UsbBusAllocator<Bus>> = None])]
+    fn init(ctx: init::Context) -> (Shared, Local, init::Monotonics) {
+        let (
+            board::Common {
+                pit: (mut timer, _, _, _),
+                usb1,
+                usbnc1,
+                usbphy1,
+                mut dma,
+                ..
+            },
+            board::Specifics { led, console, .. },
+        ) = board::new();
+        timer.set_load_timer_value(LPUART_POLL_INTERVAL_MS);
+        timer.set_interrupt_enable(true);
+        timer.enable();
+
+        let dma_a = dma[board::BOARD_DMA_A_INDEX].take().unwrap();
+        let poller = board::logging::lpuart(FRONTEND, console, dma_a);
+
+        let usbd = hal::usbd::Instances {
+            usb: usb1,
+            usbnc: usbnc1,
+            usbphy: usbphy1,
+        };
+
+        let bus = BusAdapter::with_speed(usbd, &EP_MEMORY, &EP_STATE, SPEED);
+        bus.set_interrupts(true);
+
+        let bus = ctx.local.bus.insert(UsbBusAllocator::new(bus));
+        let class = SerialPort::new(bus);
+        let device = UsbDeviceBuilder::new(bus, VID_PID)
+            .product(PRODUCT)
+            .device_class(usbd_serial::USB_CLASS_CDC)
+            .max_packet_size_0(64)
+            .build();
+
+        (
+            Shared {},
+            Local {
+                class,
+                device,
+                led,
+                poller,
+                timer,
+            },
+            init::Monotonics(),
+        )
+    }
+
+    /// Occasionally try to poll the logger.
+    #[task(binds = BOARD_PIT, local = [poller, timer], priority = 1)]
+    fn pit_interrupt(ctx: pit_interrupt::Context) {
+        while ctx.local.timer.is_elapsed() {
+            ctx.local.timer.clear_elapsed();
+        }
+        ctx.local.poller.poll();
+    }
+
+    #[task(binds = BOARD_USB1, local = [class, device, led, configured: bool = false], priority = 2)]
+    fn usb1(ctx: usb1::Context) {
+        let usb1::LocalResources {
+            class,
+            device,
+            configured,
+            led,
+        } = ctx.local;
+
+        if device.poll(&mut [class]) {
+            if device.state() == UsbDeviceState::Configured {
+                if !*configured {
+                    device.bus().configure();
+                }
+                *configured = true;
+
+                let mut buffer = [0; 64];
+                match class.read(&mut buffer) {
+                    Ok(count) => {
+                        led.toggle();
+                        class.write(&buffer[..count]).ok();
+                        log::info!(
+                            "Received '{}' from the host",
+                            core::str::from_utf8(&buffer[..count]).unwrap_or("???")
+                        );
+                    }
+                    Err(usb_device::UsbError::WouldBlock) => {}
+                    Err(err) => log::error!("{:?}", err),
+                }
+            } else {
+                *configured = false;
+            }
+        }
+    }
+}

--- a/examples/rtic_usb_test_class.rs
+++ b/examples/rtic_usb_test_class.rs
@@ -1,0 +1,144 @@
+//! Implements the usb-device test class.
+//!
+//! This is an important example for USB device testing. It turns your board
+//! into a USB device that can be tested from the usb-device host-side testing
+//! framework. See the usb-device documentation for more information on the test.
+//!
+//! The gist of the testing process:
+//!
+//! 1. Flash this example onto your board. Keep your board connected to your host.
+//! 2. Clone the usb-device repository.
+//! 3. Run `cargo test` in the usb-device directory.
+//!
+//! The test harness should detect your board and execute tests against it.
+//! All of those tests should pass.
+//!
+//! If you're playing the benchmark game and optimizing for bulk read / write
+//! throughput, configure your runtime to place as much as possible into TCM.
+
+#![no_std]
+#![no_main]
+
+#[rtic::app(device = board, peripherals = false)]
+mod app {
+    use hal::usbd::{BusAdapter, EndpointMemory, EndpointState, Speed};
+    use imxrt_hal as hal;
+
+    use usb_device::{
+        bus::UsbBusAllocator,
+        device::{UsbDevice, UsbDeviceState},
+        test_class::TestClass,
+    };
+
+    /// Change me if you want to test a full-speed USB device.
+    ///
+    /// *NOTE*: if you change this, you need to *disable* the usb-device
+    /// "test-class-high-speed" feature, which is enabled by default. See
+    /// the top-level Cargo.toml.
+    const SPEED: Speed = Speed::High;
+    /// How frequently should we poll the logger?
+    const LPUART_POLL_INTERVAL_MS: u32 = board::PIT_FREQUENCY / 1_000 * 100;
+    /// Change me to change how log messages are serialized.
+    ///
+    /// If changing to `Defmt`, you'll need to update the logging macros in
+    /// this example. You'll also need to make sure the USB device you're debugging
+    /// uses `defmt`.
+    const FRONTEND: board::logging::Frontend = board::logging::Frontend::Log;
+
+    /// This allocation is shared across all USB endpoints. It needs to be large
+    /// enough to hold the maximum packet size for *all* endpoints. If you start
+    /// noticing panics, check to make sure that this is large enough for all endpoints.
+    static EP_MEMORY: EndpointMemory<4096> = EndpointMemory::new();
+    /// This manages the endpoints. It's large enough to hold the maximum number
+    /// of endpoints; we're not using all the endpoints in this example.
+    static EP_STATE: EndpointState = EndpointState::max_endpoints();
+
+    type Bus = BusAdapter;
+
+    #[local]
+    struct Local {
+        class: TestClass<'static, Bus>,
+        device: UsbDevice<'static, Bus>,
+        poller: board::logging::Poller,
+        timer: hal::pit::Pit<0>,
+    }
+
+    #[shared]
+    struct Shared {}
+
+    #[init(local = [bus: Option<UsbBusAllocator<Bus>> = None])]
+    fn init(ctx: init::Context) -> (Shared, Local, init::Monotonics) {
+        let (
+            board::Common {
+                pit: (mut timer, _, _, _),
+                usb1,
+                usbnc1,
+                usbphy1,
+                mut dma,
+                ..
+            },
+            board::Specifics { console, .. },
+        ) = board::new();
+        timer.set_load_timer_value(LPUART_POLL_INTERVAL_MS);
+        timer.set_interrupt_enable(true);
+        timer.enable();
+
+        let dma_a = dma[board::BOARD_DMA_A_INDEX].take().unwrap();
+        let poller = board::logging::lpuart(FRONTEND, console, dma_a);
+
+        let usbd = hal::usbd::Instances {
+            usb: usb1,
+            usbnc: usbnc1,
+            usbphy: usbphy1,
+        };
+
+        let bus = BusAdapter::with_speed(usbd, &EP_MEMORY, &EP_STATE, SPEED);
+        bus.set_interrupts(true);
+
+        let bus = ctx.local.bus.insert(UsbBusAllocator::new(bus));
+        let class = TestClass::new(bus);
+        let device = class.make_device_builder(bus).max_packet_size_0(64).build();
+
+        (
+            Shared {},
+            Local {
+                class,
+                device,
+                poller,
+                timer,
+            },
+            init::Monotonics(),
+        )
+    }
+
+    /// Occasionally try to poll the logger.
+    #[task(binds = BOARD_PIT, local = [poller, timer], priority = 1)]
+    fn pit_interrupt(ctx: pit_interrupt::Context) {
+        while ctx.local.timer.is_elapsed() {
+            ctx.local.timer.clear_elapsed();
+        }
+        ctx.local.poller.poll();
+    }
+
+    #[task(binds = BOARD_USB1, local = [class, device, configured: bool = false], priority = 2)]
+    fn usb1(ctx: usb1::Context) {
+        let usb1::LocalResources {
+            class,
+            device,
+            configured,
+        } = ctx.local;
+
+        if device.poll(&mut [class]) {
+            if device.state() == UsbDeviceState::Configured {
+                if !*configured {
+                    device.bus().configure();
+                }
+                *configured = true;
+
+                class.poll();
+            } else {
+                *configured = false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Recent USB troubleshooting ([here](https://github.com/mciantyre/teensy4-rs/discussions/132) and [here](https://github.com/imxrt-rs/imxrt-usbd/pull/21)) had me wanting USB examples on easily debug-able boards. The examples maintained in the imxrt-usbd repository only work on the Teensy 4, and there's no straightforward way to add new board support. Since imxrt-hal exports imxrt-usbd, I figure we could demonstrate the driver here, then receive the cross-board testing for free.

This PR ports the four primary USB examples from the imxrt-usbd repository. It rewrites them all to use RTIC. I tested them across my three available boards (Teensy 4, 1010EVK, 1170EVK) in various build and release configurations. The test-class and serial examples worked as expected against my macOS and Linux (RPi) hosts; HID examples worked on my macOS host.

See commit messages for more notes. If accepted, I'll remove the examples in the imxrt-usbd repository and refer users here.