### PR TITLE
LPSPI sampling configuration API

### DIFF
--- a/src/common/lpspi.rs
+++ b/src/common/lpspi.rs
@@ -507,7 +507,7 @@ impl<P, const N: u8> Lpspi<P, N> {
     /// When set to `SamplePoint::DelayedEdge`, the LPSPI master will sample the input data
     /// on a delayed LPSPI_SCK edge, which improves the setup time when sampling data.
     ///
-    /// On [`init`](`Lpspi::init`), the `SamplePoint::DelayedEdge` congfiguration is set.
+    /// This driver sets `SamplePoint::DelayedEdge` by default.
     ///
     /// When using a non-hardware controlled chip select pin, the `SamplePoint::DelayedEdge` can lead to
     /// rx fifo overruns, so the `SamplePoint::Edge` configuration may be preferable.

--- a/src/common/lpspi.rs
+++ b/src/common/lpspi.rs
@@ -502,25 +502,6 @@ impl<P, const N: u8> Lpspi<P, N> {
         Interrupts::from_bits_truncate(ral::read_reg!(ral::lpspi, self.lpspi, IER))
     }
 
-    /// Set the sampling point of the LPSPI in master mode.
-    ///
-    /// When set to `SamplePoint::DelayedEdge`, the LPSPI master will sample the input data
-    /// on a delayed LPSPI_SCK edge, which improves the setup time when sampling data.
-    ///
-    /// This driver sets `SamplePoint::DelayedEdge` by default.
-    ///
-    /// When using a non-hardware controlled chip select pin, the `SamplePoint::DelayedEdge` can lead to
-    /// rx fifo overruns, so the `SamplePoint::Edge` configuration may be preferable.
-    ///
-    pub fn set_sample_point(&mut self, sample_point: SamplePoint) {
-        match sample_point {
-            SamplePoint::Edge => ral::modify_reg!(ral::lpspi, self.lpspi, CFGR1, SAMPLE: SAMPLE_0),
-            SamplePoint::DelayedEdge => {
-                ral::modify_reg!(ral::lpspi, self.lpspi, CFGR1, SAMPLE: SAMPLE_1)
-            }
-        }
-    }
-
     /// Set the interrupt enable bits.
     ///
     /// This writes the bits described by `interrupts` as is to the register.
@@ -977,6 +958,25 @@ impl<'a, const N: u8> Disabled<'a, N> {
         }
 
         watermark
+    }
+
+    /// Set the sampling point of the LPSPI in master mode.
+    ///
+    /// When set to `SamplePoint::DelayedEdge`, the LPSPI master will sample the input data
+    /// on a delayed LPSPI_SCK edge, which improves the setup time when sampling data.
+    ///
+    /// This driver sets `SamplePoint::DelayedEdge` by default.
+    ///
+    /// When using a non-hardware controlled chip select pin, the `SamplePoint::DelayedEdge` can lead to
+    /// rx fifo overruns, so the `SamplePoint::Edge` configuration may be preferable.
+    ///
+    pub fn set_sample_point(&mut self, sample_point: SamplePoint) {
+        match sample_point {
+            SamplePoint::Edge => ral::modify_reg!(ral::lpspi, self.lpspi, CFGR1, SAMPLE: SAMPLE_0),
+            SamplePoint::DelayedEdge => {
+                ral::modify_reg!(ral::lpspi, self.lpspi, CFGR1, SAMPLE: SAMPLE_1)
+            }
+        }
     }
 }
 

--- a/src/common/lpspi.rs
+++ b/src/common/lpspi.rs
@@ -1,4 +1,3 @@
-@@ -0,0 +1,1059 @@
 //! Low-power serial peripheral interface.
 //!
 //! [`Lpspi`] implements select embedded HAL SPI traits for coordinating SPI I/O.

--- a/src/common/lpspi.rs
+++ b/src/common/lpspi.rs
@@ -111,7 +111,6 @@ pub enum SamplePoint {
     DelayedEdge,
 }
 
-
 /// Possible errors when interfacing the LPSPI.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LpspiError {
@@ -504,21 +503,22 @@ impl<P, const N: u8> Lpspi<P, N> {
     }
 
     /// Set the sampling point of the LPSPI in master mode.
-    /// 
-    /// When set to `SamplePoint::DelayedEdge`, the LPSPI master will sample the input data 
+    ///
+    /// When set to `SamplePoint::DelayedEdge`, the LPSPI master will sample the input data
     /// on a delayed LPSPI_SCK edge, which improves the setup time when sampling data.
-    /// 
+    ///
     /// On [`init`](`Lpspi::init`), the `SamplePoint::DelayedEdge` congfiguration is set.
-    /// 
-    /// When using a non-hardware controlled chip select pin, the `SamplePoint::DelayedEdge` can lead to 
+    ///
+    /// When using a non-hardware controlled chip select pin, the `SamplePoint::DelayedEdge` can lead to
     /// rx fifo overruns, so the `SamplePoint::Edge` configuration may be preferable.
-    /// 
+    ///
     pub fn set_sample_point(&mut self, sample_point: SamplePoint) {
         match sample_point {
             SamplePoint::Edge => ral::modify_reg!(ral::lpspi, self.lpspi, CFGR1, SAMPLE: SAMPLE_0),
-            SamplePoint::DelayedEdge => ral::modify_reg!(ral::lpspi, self.lpspi, CFGR1, SAMPLE: SAMPLE_1),
+            SamplePoint::DelayedEdge => {
+                ral::modify_reg!(ral::lpspi, self.lpspi, CFGR1, SAMPLE: SAMPLE_1)
+            }
         }
-        
     }
 
     /// Set the interrupt enable bits.


### PR DESCRIPTION
Expose a public method to allow users to change the sampling point of an LPSPI peripheral.

I've experienced RX FIFO overruns when the SAMPLE: SAMPLE_1 (delayed edge) is used with non-hardware controlled chip select pins (ie, manually driving a CS pin with GPIO `embedded_hal` traits). Changing this configuration setting to SAMPLE_0 fixed the issue.

Tested on a Teensy 4.0 and 4.1 with a Trinamic TMC5130 stepper driver IC.  

When using CS0 (pin 10 on Teensy 4.X), the  `SAMPLE_1` setting works fine. When using pin 4, the `SAMPLE_0` must be used to avoid overruns. I'm curious if anyone else has experienced this issue.