### PR TITLE
Add 10xx FlexIO CCM configuration

### DIFF
--- a/src/chip/imxrt10xx.rs
+++ b/src/chip/imxrt10xx.rs
@@ -3,6 +3,7 @@
 //! Shared modules may rely on configurations from the `config` module.
 
 pub mod adc;
+#[macro_use]
 pub mod ccm;
 pub mod dcdc;
 #[path = "dma.rs"]

--- a/src/chip/imxrt10xx/imxrt1010.rs
+++ b/src/chip/imxrt10xx/imxrt1010.rs
@@ -130,5 +130,12 @@ pub(crate) mod ccm {
             pub const TracClk: Clko2Selection = Clko2Selection::TraceClk;
         }
     }
+
+    ccm_flexio!(
+        flexio1_clk, "FLEXIO1",
+        divider: (CS1CDR, FLEXIO1_CLK_PODF),
+        predivider: (CS1CDR, FLEXIO1_CLK_PRED),
+        selection: (CSCMR2, FLEXIO1_CLK_SEL),
+    );
 }
 pub(crate) const DMA_CHANNEL_COUNT: usize = 16;

--- a/src/chip/imxrt10xx/imxrt1020.rs
+++ b/src/chip/imxrt10xx/imxrt1020.rs
@@ -144,6 +144,13 @@ pub(crate) mod ccm {
             Spdif0Clk = 0b11101,
         }
     }
+
+    ccm_flexio!(
+        flexio1_clk, "FLEXIO1",
+        divider: (CS1CDR, FLEXIO1_CLK_PODF),
+        predivider: (CS1CDR, FLEXIO1_CLK_PRED),
+        selection: (CSCMR2, FLEXIO1_CLK_SEL),
+    );
 }
 
 pub(crate) const DMA_CHANNEL_COUNT: usize = 32;

--- a/src/chip/imxrt10xx/imxrt1060.rs
+++ b/src/chip/imxrt10xx/imxrt1060.rs
@@ -105,6 +105,20 @@ pub(crate) mod ccm {
 
         pub enum Clko2Selection {}
     }
+
+    ccm_flexio!(
+        flexio1_clk, "FLEXIO1",
+        divider: (CDCDR, FLEXIO1_CLK_PODF),
+        predivider: (CDCDR, FLEXIO1_CLK_PRED),
+        selection: (CDCDR, FLEXIO1_CLK_SEL),
+    );
+
+    ccm_flexio!(
+        flexio2_clk, "FLEXIO2",
+        divider: (CS1CDR, FLEXIO2_CLK_PODF),
+        predivider: (CS1CDR, FLEXIO2_CLK_PRED),
+        selection: (CSCMR2, FLEXIO2_CLK_SEL),
+    );
 }
 
 pub(crate) const DMA_CHANNEL_COUNT: usize = 32;


### PR DESCRIPTION
This adds support for setting source clock and dividers for FlexIO clock roots in accordance with the RMs

This is WIP because I haven't gotten around to testing the current version on actual hardware yet, but I'd like feedback on the general approach.
The issue here is that FLEXIO1_CLK_ROOT on 1010/1020 is FLEXIO2_CLK_ROOT on 106x, so there is some magic involved in getting the module names and doc comments right. Due to this it might also make sense to move this into a separate module and re-export it.