### PR TITLE
Use defmt-rtt and panic-probe for evk boards

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,4 +4,5 @@ rustflags = [
     "-C", "link-arg=-Tdefmt.x",
     "-C", "link-arg=-Tdevice.x",
     "-C", "link-arg=-error-limit=0",
+    "-C", "link-arg=-nmagic",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ members = [
 imxrt-dma = "0.1"
 imxrt-iomuxc = "0.2.1"
 imxrt-hal = { version = "0.5", path = "." }
-imxrt-log = { path = "logging" }
+imxrt-log = { path = "logging", default-features = false, features = ["log", "lpuart", "usbd"] }
 imxrt-ral = "0.5"
 imxrt-rt = "0.1"
 imxrt-usbd = "0.2"
@@ -165,6 +165,9 @@ required-features = ["board/imxrt-log"]
 [[example]]
 name = "rtic_logging"
 required-features = ["board/imxrt-log"]
+
+[[example]]
+name = "rtic_defmt_rtt"
 
 [[example]]
 name = "hal_i2c_lcd1602"

--- a/board/Cargo.toml
+++ b/board/Cargo.toml
@@ -26,6 +26,7 @@ workspace = true
 [dependencies.imxrt-log]
 workspace = true
 optional = true
+default-features = false
 
 [dependencies.imxrt-usbd]
 workspace = true
@@ -52,6 +53,17 @@ version = "0.2"
 version = "0.3"
 optional = true
 
+# knurling-rs style defmt-rtt with panic-probe
+[target.thumbv7em-none-eabihf.dependencies.defmt-rtt]
+version = "0.4"
+optional = true
+
+[target.thumbv7em-none-eabihf.dependencies.panic-probe]
+version = "0.3"
+features = ["print-defmt"]
+optional = true
+
+# alternative rtt target with panic printing
 [target.thumbv7em-none-eabihf.dependencies.rtt-target]
 version = "0.3"
 optional = true
@@ -80,8 +92,8 @@ imxrt1010evk = [
     "imxrt-ral/imxrt1011",
     "imxrt-hal/imxrt1010",
     "imxrt1010evk-fcb",
-    "rtt-target",
-    "panic-rtt-target",
+    "defmt-rtt",
+    "panic-probe",
     "imxrt-log",
 ]
 imxrt1060evk = [
@@ -89,8 +101,8 @@ imxrt1060evk = [
     "imxrt-ral/imxrt1062",
     "imxrt-hal/imxrt1060",
     "imxrt1060evk-fcb",
-    "rtt-target",
-    "panic-rtt-target",
+    "defmt-rtt",
+    "panic-probe",
     "imxrt-log",
 ]
 teensy4 = [
@@ -100,6 +112,7 @@ teensy4 = [
     "teensy4-fcb",
     "teensy4-panic",
     "imxrt-log",
+    "imxrt-log/defmt",
 ]
 imxrt1170evk-cm7 = [
     "imxrt-iomuxc/imxrt1170",
@@ -109,6 +122,7 @@ imxrt1170evk-cm7 = [
     "rtt-target",
     "panic-rtt-target",
     "imxrt-log",
+    "imxrt-log/defmt",
 ]
 
 # Some boards (Teensy 4) require a resource

--- a/board/Cargo.toml
+++ b/board/Cargo.toml
@@ -112,7 +112,7 @@ teensy4 = [
     "teensy4-fcb",
     "teensy4-panic",
     "imxrt-log",
-    "imxrt-log/defmt",
+    "logging-defmt",
 ]
 imxrt1170evk-cm7 = [
     "imxrt-iomuxc/imxrt1170",
@@ -123,6 +123,7 @@ imxrt1170evk-cm7 = [
     "panic-probe",
     "imxrt-log",
 ]
+logging-defmt = ["imxrt-log/defmt"]
 
 # Some boards (Teensy 4) require a resource
 # configuration to enable the (easily accessible)

--- a/board/Cargo.toml
+++ b/board/Cargo.toml
@@ -119,10 +119,9 @@ imxrt1170evk-cm7 = [
     "imxrt-ral/imxrt1176_cm7",
     "imxrt-hal/imxrt1170",
     "imxrt1170evk-fcb",
-    "rtt-target",
-    "panic-rtt-target",
+    "defmt-rtt",
+    "panic-probe",
     "imxrt-log",
-    "imxrt-log/defmt",
 ]
 
 # Some boards (Teensy 4) require a resource

--- a/board/build.rs
+++ b/board/build.rs
@@ -31,11 +31,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 RuntimeBuilder::from_flexspi(Family::Imxrt1010, 16 * 1024 * 1024)
                     .flexram_banks(imxrt_rt::FlexRamBanks {
                         ocram: 1,
-                        itcm: 1,
-                        dtcm: 2,
+                        itcm: 2,
+                        dtcm: 1,
                     })
-                    .bss(Memory::Dtcm)
-                    .data(Memory::Dtcm)
                     .uninit(Memory::Dtcm)
                     .build()?;
                 println!("cargo:rustc-cfg=board=\"imxrt1010evk\"");

--- a/board/src/imxrt1010evk.rs
+++ b/board/src/imxrt1010evk.rs
@@ -13,12 +13,19 @@
 //! that you populate and de-populate certain resistors. Compile-time
 //! configurations are faster than working with 0402 resistors.
 
+use defmt_rtt as _;
+
 use crate::{hal, iomuxc::imxrt1010 as iomuxc, ral};
 
 #[cfg(target_arch = "arm")]
 use imxrt1010evk_fcb as _;
-#[cfg(target_arch = "arm")]
-use panic_rtt_target as _;
+
+use panic_probe as _;
+
+#[defmt::panic_handler]
+fn panic() -> ! {
+    cortex_m::asm::udf();
+}
 
 mod imxrt10xx {
     pub mod clock;
@@ -148,9 +155,6 @@ pub struct Specifics {
 
 impl Specifics {
     pub(crate) fn new(_: &mut crate::Common) -> Self {
-        #[cfg(target_arch = "arm")]
-        rtt_target::rtt_init_print!();
-
         let iomuxc = unsafe { ral::iomuxc::IOMUXC::instance() };
         let mut iomuxc = super::convert_iomuxc(iomuxc);
         configure_pins(&mut iomuxc);

--- a/board/src/imxrt1060evk.rs
+++ b/board/src/imxrt1060evk.rs
@@ -8,12 +8,19 @@
 //! exactly the same. I'm not sure if this is generally
 //! true.)
 
+use defmt_rtt as _;
+
 use crate::{hal, iomuxc::imxrt1060 as iomuxc, ral};
+
+use panic_probe as _;
+
+#[defmt::panic_handler]
+fn panic() -> ! {
+    cortex_m::asm::udf();
+}
 
 #[cfg(target_arch = "arm")]
 use imxrt1060evk_fcb as _;
-#[cfg(target_arch = "arm")]
-use panic_rtt_target as _;
 
 mod imxrt10xx {
     pub(crate) mod clock;
@@ -131,9 +138,6 @@ pub struct Specifics {
 
 impl Specifics {
     pub(crate) fn new(_: &mut crate::Common) -> Self {
-        #[cfg(target_arch = "arm")]
-        rtt_target::rtt_init_print!();
-
         // Manually configuring IOMUXC_SNVS pads, since there's no
         // equivalent API in imxrt-iomuxc.
         let iomuxc_snvs = unsafe { ral::iomuxc_snvs::IOMUXC_SNVS::instance() };

--- a/board/src/imxrt1170evk-cm7.rs
+++ b/board/src/imxrt1170evk-cm7.rs
@@ -9,9 +9,16 @@ mod imxrt11xx {
 use imxrt11xx::clock_tree;
 
 #[cfg(target_arch = "arm")]
-use imxrt1170evk_fcb as _;
+use defmt_rtt as _;
 #[cfg(target_arch = "arm")]
-use panic_rtt_target as _;
+use imxrt1170evk_fcb as _;
+
+use panic_probe as _;
+
+#[defmt::panic_handler]
+fn defmt_panic() -> ! {
+    cortex_m::asm::udf();
+}
 
 /// You'll find log messages using the serial console, through the DAP.
 pub(crate) const DEFAULT_LOGGING_BACKEND: crate::logging::Backend = crate::logging::Backend::Lpuart;
@@ -159,9 +166,6 @@ pub struct Specifics {
 
 impl Specifics {
     pub(crate) fn new(common: &mut crate::Common) -> Self {
-        #[cfg(target_arch = "arm")]
-        rtt_target::rtt_init_print!();
-
         // Manually configuring IOMUXC_SNVS pads, since there's no
         // equivalent API in imxrt-iomuxc.
         let iomuxc_snvs = unsafe { ral::iomuxc_snvs::IOMUXC_SNVS::instance() };

--- a/board/src/lib.rs
+++ b/board/src/lib.rs
@@ -298,6 +298,7 @@ pub mod logging {
     pub enum Frontend {
         /// Use the `log` crate.
         Log,
+        #[cfg(feature = "imxrt-log/defmt")]
         /// Use `defmt`.
         Defmt,
     }
@@ -329,9 +330,11 @@ pub mod logging {
                 imxrt_log::log::usbd(usbd, imxrt_log::Interrupts::Enabled).unwrap()
             }
             // Defmt frontends...
+            #[cfg(feature = "imxrt-log/defmt")]
             (Frontend::Defmt, Backend::Lpuart) => {
                 imxrt_log::defmt::lpuart(lpuart, dma, imxrt_log::Interrupts::Enabled).unwrap()
             }
+            #[cfg(feature = "imxrt-log/defmt")]
             (Frontend::Defmt, Backend::Usbd) => {
                 imxrt_log::defmt::usbd(usbd, imxrt_log::Interrupts::Enabled).unwrap()
             }
@@ -354,6 +357,7 @@ pub mod logging {
             Frontend::Log => {
                 imxrt_log::log::lpuart(lpuart, dma_channel, imxrt_log::Interrupts::Enabled).unwrap()
             }
+            #[cfg(feature = "imxrt-log/defmt")]
             Frontend::Defmt => {
                 imxrt_log::defmt::lpuart(lpuart, dma_channel, imxrt_log::Interrupts::Enabled)
                     .unwrap()

--- a/board/src/lib.rs
+++ b/board/src/lib.rs
@@ -298,7 +298,7 @@ pub mod logging {
     pub enum Frontend {
         /// Use the `log` crate.
         Log,
-        #[cfg(feature = "imxrt-log/defmt")]
+        #[cfg(feature = "logging-defmt")]
         /// Use `defmt`.
         Defmt,
     }
@@ -330,11 +330,11 @@ pub mod logging {
                 imxrt_log::log::usbd(usbd, imxrt_log::Interrupts::Enabled).unwrap()
             }
             // Defmt frontends...
-            #[cfg(feature = "imxrt-log/defmt")]
+            #[cfg(feature = "logging-defmt")]
             (Frontend::Defmt, Backend::Lpuart) => {
                 imxrt_log::defmt::lpuart(lpuart, dma, imxrt_log::Interrupts::Enabled).unwrap()
             }
-            #[cfg(feature = "imxrt-log/defmt")]
+            #[cfg(feature = "logging-defmt")]
             (Frontend::Defmt, Backend::Usbd) => {
                 imxrt_log::defmt::usbd(usbd, imxrt_log::Interrupts::Enabled).unwrap()
             }
@@ -357,7 +357,7 @@ pub mod logging {
             Frontend::Log => {
                 imxrt_log::log::lpuart(lpuart, dma_channel, imxrt_log::Interrupts::Enabled).unwrap()
             }
-            #[cfg(feature = "imxrt-log/defmt")]
+            #[cfg(feature = "logging-defmt")]
             Frontend::Defmt => {
                 imxrt_log::defmt::lpuart(lpuart, dma_channel, imxrt_log::Interrupts::Enabled)
                     .unwrap()

--- a/examples/rtic_defmt_rtt.rs
+++ b/examples/rtic_defmt_rtt.rs
@@ -1,0 +1,91 @@
+//! Demonstrates defmt logging using RTT with RTIC.
+
+#![no_std]
+#![no_main]
+
+#[rtic::app(device = board, peripherals = false, dispatchers = [BOARD_SWTASK0])]
+mod app {
+
+    //
+    // Configure the demo below.
+    //
+
+    /// How frequently (milliseconds) should we make a log message?
+    ///
+    /// Decrease this constant to log more frequently.
+    const MAKE_LOG_INTERVAL_MS: u32 = board::PIT_FREQUENCY / 1_000 * 250;
+
+    use imxrt_hal as hal;
+    //
+    // End configurations.
+    //
+
+    #[local]
+    struct Local {
+        /// Toggle when we make a log.
+        led: board::Led,
+        /// This timer tells us how frequently to generate
+        /// logs. It's always used.
+        make_log: hal::pit::Pit<2>,
+    }
+
+    #[shared]
+    struct Shared {}
+
+    #[init]
+    fn init(cx: init::Context) -> (Shared, Local, init::Monotonics) {
+        let mut cortex_m = cx.core;
+        let (
+            board::Common {
+                pit: (_, _, mut make_log, _),
+                ..
+            },
+            board::Specifics { led, .. },
+        ) = board::new();
+        cortex_m.DCB.enable_trace();
+        cortex_m::peripheral::DWT::unlock();
+        cortex_m.DWT.enable_cycle_counter();
+
+        make_log.set_load_timer_value(MAKE_LOG_INTERVAL_MS);
+        make_log.set_interrupt_enable(true);
+        make_log.enable();
+
+        (Shared {}, Local { led, make_log }, init::Monotonics())
+    }
+
+    #[task(binds = BOARD_PIT, local = [led, make_log, counter: u32 = 0], priority = 1)]
+    fn pit_interrupt(cx: pit_interrupt::Context) {
+        let pit_interrupt::LocalResources {
+            make_log,
+            led,
+            counter,
+        } = cx.local;
+
+        // Is it time for us to send a new log message?
+        if make_log.is_elapsed() {
+            led.toggle();
+            while make_log.is_elapsed() {
+                make_log.clear_elapsed();
+            }
+
+            let count = cycles(|| {
+                defmt::println!("Hello from defmt over RTT! The counter is {=u32}", counter)
+            });
+
+            defmt::println!(
+                "That last message took {=u32} cycles to be copied into the logging buffer",
+                count
+            );
+
+            *counter += 1;
+        }
+    }
+
+    /// Count the clock cycles required to execute `f`
+    fn cycles<F: FnOnce()>(f: F) -> u32 {
+        let start = cortex_m::peripheral::DWT::cycle_count();
+        f();
+        let end = cortex_m::peripheral::DWT::cycle_count();
+        end - start
+    }
+}

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -49,6 +49,7 @@ workspace = true
 default = ["defmt", "log", "lpuart", "usbd"]
 lpuart = ["imxrt-hal"]
 usbd = ["dep:imxrt-usbd", "dep:usb-device", "dep:usbd-serial"]
+defmt = ["dep:defmt"]
 
 [dev-dependencies.cortex-m]
 version = "0.7"
@@ -62,4 +63,4 @@ workspace = true
 
 [package.metadata.docs.rs]
 default-target = "thumbv7em-none-eabihf"
-features = ["imxrt-ral/imxrt1062", "imxrt-hal/imxrt1060"]
+features = ["defmt", "imxrt-ral/imxrt1062", "imxrt-hal/imxrt1060"]

--- a/logging/src/log.rs
+++ b/logging/src/log.rs
@@ -7,7 +7,7 @@
 //! and serialization into the buffer. When it's time to copy the data into the circular buffer, the
 //! implementation takes a short critical section.
 //!
-//! See [`LoggingConfig`](crate::log::LoggingConfig) to learn more about the runtime filters.
+//! See [`LoggingConfig`] to learn more about the runtime filters.
 //! See the `log` package documentation to learn about static filters.
 
 mod filters;


### PR DESCRIPTION
The evk boards have a built in debug probe. When running firmware with probe-rs defmt-rtt provides a very fast channel of low cost debug println's that everyone finds really helpful.

Using panic-probe with defmt-rtt has a second benefit in allowing for programs to inform probe-rs the firmware has exited cleanly. This can be used for writing samples and tests that exit.

This also makes the imxrt-log defmt feature optional to the boards otherwise the two implementations of the defmt logger cause duplicate symbols to show up.