### PR TITLE
Prepare LPSPI driver for `embedded-hal 1.0` rework

### DIFF
--- a/board/src/imxrt1010evk.rs
+++ b/board/src/imxrt1010evk.rs
@@ -168,7 +168,7 @@ impl Specifics {
         let gpio2 = unsafe { ral::gpio::GPIO2::instance() };
         let mut gpio2 = hal::gpio::Port::new(gpio2);
 
-        let led = gpio1.output(iomuxc.gpio.p11);
+        let led = gpio1.output(iomuxc.gpio.p11, false);
         let button = gpio2.input(iomuxc.gpio_sd.p05);
 
         let lpuart1 = unsafe { ral::lpuart::LPUART1::instance() };
@@ -191,13 +191,12 @@ impl Specifics {
                 sdo: iomuxc.gpio_ad.p04,
                 sdi: iomuxc.gpio_ad.p03,
                 sck: iomuxc.gpio_ad.p06,
-                pcs0: iomuxc.gpio_ad.p05,
             };
             let mut spi = Spi::new(lpspi1, pins);
             spi.disabled(|spi| {
                 spi.set_clock_hz(super::LPSPI_CLK_FREQUENCY, super::SPI_BAUD_RATE_FREQUENCY);
             });
-            let spi_cs = todo!();
+            let spi_cs = gpio1.output(iomuxc.gpio_ad.p05, true);
             (spi, spi_cs)
         };
 

--- a/board/src/imxrt1060evk.rs
+++ b/board/src/imxrt1060evk.rs
@@ -156,11 +156,14 @@ impl Specifics {
 
         let gpio1 = unsafe { ral::gpio::GPIO1::instance() };
         let mut gpio1 = hal::gpio::Port::new(gpio1);
-        let led = gpio1.output(iomuxc.gpio_ad_b0.p09);
+        let led = gpio1.output(iomuxc.gpio_ad_b0.p09, false);
 
         let gpio5 = unsafe { ral::gpio::GPIO5::instance() };
         let mut gpio5 = hal::gpio::Port::new(gpio5);
         let button = hal::gpio::Input::without_pin(&mut gpio5, 0);
+
+        let gpio3 = unsafe { ral::gpio::GPIO3::instance() };
+        let mut gpio3 = hal::gpio::Port::new(gpio3);
 
         let lpuart1 = unsafe { ral::lpuart::LPUART1::instance() };
         let mut console = hal::lpuart::Lpuart::new(
@@ -182,13 +185,12 @@ impl Specifics {
                 sdo: iomuxc.gpio_sd_b0.p02,
                 sdi: iomuxc.gpio_sd_b0.p03,
                 sck: iomuxc.gpio_sd_b0.p00,
-                pcs0: iomuxc.gpio_sd_b0.p01,
             };
             let mut spi = Spi::new(lpspi1, pins);
             spi.disabled(|spi| {
                 spi.set_clock_hz(super::LPSPI_CLK_FREQUENCY, super::SPI_BAUD_RATE_FREQUENCY);
             });
-            let spi_cs = todo!();
+            let spi_cs = gpio3.output(iomuxc.gpio_sd_b0.p01, true);
             (spi, spi_cs)
         };
         #[cfg(not(feature = "spi"))]

--- a/board/src/imxrt1170evk-cm7.rs
+++ b/board/src/imxrt1170evk-cm7.rs
@@ -189,7 +189,7 @@ impl Specifics {
 
         let gpio9 = unsafe { ral::gpio::GPIO9::instance() };
         let mut gpio9 = hal::gpio::Port::new(gpio9);
-        let led = gpio9.output(iomuxc.gpio_ad.p04);
+        let led = gpio9.output(iomuxc.gpio_ad.p04, false);
 
         let console = unsafe { ral::lpuart::Instance::<{ CONSOLE_INSTANCE }>::instance() };
         let mut console = hal::lpuart::Lpuart::new(
@@ -212,13 +212,12 @@ impl Specifics {
                 sdo: iomuxc.gpio_ad.p30,
                 sdi: iomuxc.gpio_ad.p31,
                 sck: iomuxc.gpio_ad.p28,
-                pcs0: iomuxc.gpio_ad.p29,
             };
             let mut spi = Spi::new(lpspi1, pins);
             spi.disabled(|spi| {
                 spi.set_clock_hz(LPSPI_CLK_FREQUENCY, super::SPI_BAUD_RATE_FREQUENCY);
             });
-            let spi_cs = todo!();
+            let spi_cs = gpio9.output(iomuxc.gpio_ad.p29, true);
             (spi, spi_cs)
         };
         #[cfg(not(feature = "spi"))]

--- a/board/src/teensy4.rs
+++ b/board/src/teensy4.rs
@@ -49,7 +49,6 @@ pub type SpiPins = hal::lpspi::Pins<
     iomuxc::gpio_b0::GPIO_B0_02, // SDO, P11
     iomuxc::gpio_b0::GPIO_B0_01, // SDI, P12
     iomuxc::gpio_b0::GPIO_B0_03, // SCK, P13
-    iomuxc::gpio_b0::GPIO_B0_00, // PCS0, P10
 >;
 
 #[cfg(not(feature = "spi"))]
@@ -153,7 +152,6 @@ impl Specifics {
                 sdo: iomuxc.gpio_b0.p02,
                 sdi: iomuxc.gpio_b0.p01,
                 sck: iomuxc.gpio_b0.p03,
-                pcs0: iomuxc.gpio_b0.p00,
             };
             let mut spi = Spi::new(lpspi4, pins);
             spi.disabled(|spi| {

--- a/examples/rtic_spi.rs
+++ b/examples/rtic_spi.rs
@@ -25,12 +25,12 @@ mod app {
     #[init]
     fn init(_: init::Context) -> (Shared, Local, init::Monotonics) {
         let (_, board::Specifics { mut spi, .. }) = board::new();
-        spi.disabled(|spi| {
-            // Trigger when the TX FIFO is empty.
-            spi.set_watermark(Direction::Tx, 0);
-            // Wait to receive at least 2 u32s.
-            spi.set_watermark(Direction::Rx, 1);
-        });
+
+        // Wait to receive at least 2 u32s.
+        spi.set_watermark(Direction::Rx, 1);
+        // Trigger when the TX FIFO is empty.
+        spi.set_watermark(Direction::Tx, 0);
+
         // Starts the I/O as soon as we're done initializing, since
         // the TX FIFO is empty.
         spi.set_interrupts(Interrupts::TRANSMIT_DATA);
@@ -49,7 +49,7 @@ mod app {
             spi.set_interrupts(Interrupts::RECEIVE_DATA);
 
             // Sending two u32s. Frame size is represented by bits.
-            let transaction = Transaction::new(2 * 8 * core::mem::size_of::<u32>() as u16, todo!())
+            let transaction = Transaction::new(2 * 8 * core::mem::size_of::<u32>() as u16)
                 .expect("Transaction frame size is within bounds");
             spi.enqueue_transaction(&transaction);
 

--- a/examples/rtic_spi.rs
+++ b/examples/rtic_spi.rs
@@ -49,7 +49,7 @@ mod app {
             spi.set_interrupts(Interrupts::RECEIVE_DATA);
 
             // Sending two u32s. Frame size is represented by bits.
-            let transaction = Transaction::new(2 * 8 * core::mem::size_of::<u32>() as u16)
+            let transaction = Transaction::new(2 * 8 * core::mem::size_of::<u32>() as u16, todo!())
                 .expect("Transaction frame size is within bounds");
             spi.enqueue_transaction(&transaction);
 

--- a/src/common/gpio.rs
+++ b/src/common/gpio.rs
@@ -23,7 +23,7 @@
 //! let gpio_b0_04 = // Handle to GPIO_B0_04 IOMUXC pin, provided by BSP or higher-level HAL...
 //!     # unsafe { imxrt_iomuxc::imxrt1060::gpio_b0::GPIO_B0_04::new() };
 //!
-//! let output = gpio2.output(gpio_b0_04);
+//! let output = gpio2.output(gpio_b0_04, false);
 //! output.set();
 //! output.clear();
 //! output.toggle();

--- a/src/common/lpspi.rs
+++ b/src/common/lpspi.rs
@@ -41,7 +41,6 @@
 //!     sdo: pads.gpio_b0.p02,
 //!     sdi: pads.gpio_b0.p01,
 //!     sck: pads.gpio_b0.p03,
-//!     pcs0: pads.gpio_b0.p00,
 //! };
 //!
 //! let mut spi4 = unsafe { LPSPI4::instance() };

--- a/src/common/lpspi.rs
+++ b/src/common/lpspi.rs
@@ -271,9 +271,7 @@ impl Transaction {
 
         let last_word_size = frame_size % WORD_SIZE;
 
-        (frame_size >= MIN_FRAME_SIZE)
-            && (frame_size <= MAX_FRAME_SIZE)
-            && (last_word_size >= MIN_WORD_SIZE)
+        (MIN_FRAME_SIZE..=MAX_FRAME_SIZE).contains(&frame_size) && (last_word_size >= MIN_WORD_SIZE)
     }
 
     /// Define a transaction by specifying the frame size, in bits.

--- a/src/common/lpspi.rs
+++ b/src/common/lpspi.rs
@@ -437,7 +437,10 @@ impl<P, const N: u8> Lpspi<P, N> {
         // Reset and disable
         ral::modify_reg!(ral::lpspi, spi.lpspi, CR, MEN: MEN_0, RST: RST_1);
         while spi.is_enabled() {}
-        ral::modify_reg!(ral::lpspi, spi.lpspi, CR, RST: RST_0, RTF: RTF_1, RRF: RRF_1);
+        ral::modify_reg!(ral::lpspi, spi.lpspi, CR, RST: RST_0);
+
+        // Reset Fifos
+        ral::modify_reg!(ral::lpspi, spi.lpspi, CR, RTF: RTF_1, RRF: RRF_1);
 
         // Configure master mode
         ral::write_reg!(
@@ -506,7 +509,7 @@ impl<P, const N: u8> Lpspi<P, N> {
         // Reset and disable
         ral::modify_reg!(ral::lpspi, self.lpspi, CR, MEN: MEN_0, RST: RST_1);
         while self.is_enabled() {}
-        ral::modify_reg!(ral::lpspi, self.lpspi, CR, RST: RST_0, RTF: RTF_1, RRF: RRF_1);
+        ral::modify_reg!(ral::lpspi, self.lpspi, CR, RST: RST_0);
 
         // Reset fifos
         ral::modify_reg!(ral::lpspi, self.lpspi, CR, RTF: RTF_1, RRF: RRF_1);

--- a/src/common/lpspi.rs
+++ b/src/common/lpspi.rs
@@ -468,7 +468,7 @@ impl<P, const N: u8> Lpspi<P, N> {
     ///
     /// Note that disabling does not take effect immediately; instead the
     /// peripheral finishes the current transfer and then disables itself.
-    /// It is required to check [`is_enabled`] repeatedly until the
+    /// It is required to check [`is_enabled()`](Self::is_enabled) repeatedly until the
     /// peripheral is actually disabled.
     pub fn set_enable(&mut self, enable: bool) {
         ral::modify_reg!(ral::lpspi, self.lpspi, CR, MEN: enable as u32)
@@ -588,7 +588,7 @@ impl<P, const N: u8> Lpspi<P, N> {
     /// to get the current state, then modify that state.
     ///
     /// Be aware that a critical section might be required to avoid a read-modify-write race condition
-    /// between [`interrupts`] and [`set_interrupts`].
+    /// between [`interrupts`](Self::interrupts) and [`set_interrupts`](Self::set_interrupts).
     pub fn set_interrupts(&self, interrupts: Interrupts) {
         ral::write_reg!(ral::lpspi, self.lpspi, IER, interrupts.bits());
     }
@@ -635,7 +635,7 @@ impl<P, const N: u8> Lpspi<P, N> {
     /// Clear any existing data in the SPI receive or transfer FIFOs.
     ///
     /// Note that this will **not** cancel a running transfer.
-    /// Use [`soft_reset`] for that usecase instead.
+    /// Use [`soft_reset()`](Self::soft_reset) for that usecase instead.
     #[inline]
     pub fn clear_fifo(&mut self, direction: Direction) {
         match direction {
@@ -647,7 +647,7 @@ impl<P, const N: u8> Lpspi<P, N> {
     /// Clear both FIFOs.
     ///
     /// Note that this will **not** cancel a running transfer.
-    /// Use [`soft_reset`] for that usecase instead.
+    /// Use [`soft_reset()`](Self::soft_reset) for that usecase instead.
     pub fn clear_fifos(&mut self) {
         ral::modify_reg!(ral::lpspi, self.lpspi, CR, RTF: RTF_1, RRF: RRF_1);
     }

--- a/src/common/lpspi.rs
+++ b/src/common/lpspi.rs
@@ -624,6 +624,14 @@ impl<P, const N: u8> Lpspi<P, N> {
         watermark
     }
 
+    /// Set the SPI mode for the peripheral.
+    ///
+    /// This only affects the next transfer; ongoing transfers
+    /// will not be influenced.
+    pub fn set_mode(&mut self, mode: Mode) {
+        self.mode = mode;
+    }
+
     /// Clear any existing data in the SPI receive or transfer FIFOs.
     ///
     /// Note that this will **not** cancel a running transfer.


### PR DESCRIPTION
Some fixes/modifications to the existing LPSPI driver.

This is in preparation for the `embedded-hal 1.0` rework, which will introduce a new high level driver that wraps this low level one.

Changes:
- Remove `CS_PIN` from `Spi` device
  - **Rationale:** eh1 primarily uses software CS pins. There is an extension for hardware CS pin support, but I think we should add it later as a special case instead of by default. This will simplify API design a lot.
- Split `Spi` into `Spi` + `SpiCsPin` in the `board` subcrate
- Add initial state to `gpio::Output` constructor. This is important for cases where the state needs to be set **before** enabling the pin.
- Fix/rework check for valid frame sizes (existing implementation did not cover all corner cases)
- Rework SPI clock initialization
  - Make sure we never get a baud rate **faster** than specified (slower is pretty much always ok for peripherals)
  - Configure `PCSSCK` and `SCKPCS` properly for contiguous transfers
- Some improvements in reset logic
- Add `soft_reset` that cancels the current transfer without requiring a full re-initialization
- Move more values into `enqueue_transaction` so that multiple transactions with different settings can be enqueued in series
- Add `flush` function that waits for the current transaction to be finished whilst repeatedly checking for errors
- Fix `disabled()` not waiting for the current transfer to be finished
- Take `set_watermark` out of `disabled`, because it doesn't require it.