### PR TITLE
Eagerly address select Rust 2024 edition changes

### DIFF
--- a/logging/src/defmt.rs
+++ b/logging/src/defmt.rs
@@ -97,7 +97,7 @@ mod frontend {
         // module shows that this is always accessed within the acquire-
         // release critical section, so there's only one access to this
         // mutable data.
-        unsafe { &mut ENCODER }
+        unsafe { &mut *core::ptr::addr_of_mut!(ENCODER) }
     }
 }
 

--- a/logging/src/lib.rs
+++ b/logging/src/lib.rs
@@ -253,7 +253,7 @@
 //! [log-docs]: https://docs.rs/log/0.4/log/
 
 #![no_std]
-#![warn(missing_docs)]
+#![warn(missing_docs, unsafe_op_in_unsafe_fn)]
 
 #[cfg(feature = "defmt")]
 pub mod defmt;

--- a/logging/src/log/frontend.rs
+++ b/logging/src/log/frontend.rs
@@ -67,11 +67,13 @@ pub(crate) unsafe fn init(
     // We should be preventing multiple callers with the critical section,
     // so the "only happens once" is to ensure that we're not changing the
     // static while the logger is active.
-    LOGGER.write(Logger {
-        producer: Mutex::new(RefCell::new(producer)),
-        filters: super::Filters(config.filters),
-    });
-    ::log::set_logger(&*LOGGER.as_ptr())
+    let logger = unsafe {
+        LOGGER.write(Logger {
+            producer: Mutex::new(RefCell::new(producer)),
+            filters: super::Filters(config.filters),
+        })
+    };
+    ::log::set_logger(logger)
         .map(|_| ::log::set_max_level(config.max_level))
         .map_err(|_| crate::AlreadySetError::new(()))
 }

--- a/src/common/pit.rs
+++ b/src/common/pit.rs
@@ -129,7 +129,9 @@ impl<const CHAN: u8> Pit<CHAN> {
         Const<CHAN>: Valid,
     {
         let register_block: &'_ crate::ral::pit::RegisterBlock = instance;
-        let register_block: &'static _ = core::mem::transmute(register_block);
+        // Safety: extending lifetime when we know that the register block has
+        // static lifetime.
+        let register_block: &'static _ = unsafe { core::mem::transmute(register_block) };
         Self {
             instance: register_block,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@
 //! `"unproven"` feature enabled in embedded-hal 0.2.
 
 #![no_std]
-#![warn(missing_docs)]
+#![warn(missing_docs, unsafe_op_in_unsafe_fn)]
 
 use imxrt_ral as ral;
 


### PR DESCRIPTION
The [2024 edition](https://doc.rust-lang.org/nightly/edition-guide/rust-2024/index.html) enables `unsafe_op_in_unsafe_fn` by default. This PR adds `unsafe` blocks and safety considerations throughout HAL and logging packages. There shouldn't be any functional changes.

Today's stable toolchain (1.77) also warns about the explicit references to `static mut`s. I'm taking the simple approach to resolve this eventual hard error.

Tested on an 1170EVK using the `rtic_logging` example, with both backends and both frontends.