### PR TITLE
Add non-breaking LPSPI rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Add embedded-hal 1 implementations for the following drivers:
 Introduce LPSPI improvements:
 
 - Add additional checks for LPSPI frame sizes.
-- Rework LPSPI clock settings.
+- Rework LPSPI clock settings, initialization, and disable.
 - Add `flush()` method.
 
 ## [0.5.4] 2023-11-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Add embedded-hal 1 implementations for the following drivers:
 
 - GPIO
 
+Introduce LPSPI improvements:
+
+- Add additional checks for LPSPI frame sizes.
+
 ## [0.5.4] 2023-11-26
 
 Add CCM APIs for configuring FlexIO clocks on 1000 targets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Introduce LPSPI improvements:
 - Add additional checks for LPSPI frame sizes.
 - Rework LPSPI clock settings, initialization, and disable.
 - Add `flush()` method.
+- Add `soft_reset()` method.
 
 ## [0.5.4] 2023-11-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Introduce LPSPI improvements:
 
 - Add additional checks for LPSPI frame sizes.
 - Rework LPSPI clock settings.
+- Add `flush()` method.
 
 ## [0.5.4] 2023-11-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Add embedded-hal 1 implementations for the following drivers:
 Introduce LPSPI improvements:
 
 - Add additional checks for LPSPI frame sizes.
+- Rework LPSPI clock settings.
 
 ## [0.5.4] 2023-11-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Introduce LPSPI improvements:
 - Add `soft_reset()` method.
 - Allow users to change the mode while enabled. Deprecate the corresponding
   method on the `Disabled` helper.
+- Allow users to change the watermark while enabled. Deprecate the corresponding
+  method on the `Disabled` helper.
 
 ## [0.5.4] 2023-11-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Introduce LPSPI improvements:
 - Rework LPSPI clock settings, initialization, and disable.
 - Add `flush()` method.
 - Add `soft_reset()` method.
+- Allow users to change the mode while enabled. Deprecate the corresponding
+  method on the `Disabled` helper.
 
 ## [0.5.4] 2023-11-26
 

--- a/examples/rtic_spi.rs
+++ b/examples/rtic_spi.rs
@@ -25,12 +25,10 @@ mod app {
     #[init]
     fn init(_: init::Context) -> (Shared, Local, init::Monotonics) {
         let (_, board::Specifics { mut spi, .. }) = board::new();
-        spi.disabled(|spi| {
-            // Trigger when the TX FIFO is empty.
-            spi.set_watermark(Direction::Tx, 0);
-            // Wait to receive at least 2 u32s.
-            spi.set_watermark(Direction::Rx, 1);
-        });
+        // Trigger when the TX FIFO is empty.
+        spi.set_watermark(Direction::Tx, 0);
+        // Wait to receive at least 2 u32s.
+        spi.set_watermark(Direction::Rx, 1);
         // Starts the I/O as soon as we're done initializing, since
         // the TX FIFO is empty.
         spi.set_interrupts(Interrupts::TRANSMIT_DATA);

--- a/src/common/lpspi.rs
+++ b/src/common/lpspi.rs
@@ -306,24 +306,27 @@ impl Transaction {
 ///
 /// This should only happen when the LPSPI peripheral is disabled.
 fn set_spi_clock(source_clock_hz: u32, spi_clock_hz: u32, reg: &ral::lpspi::RegisterBlock) {
-    let mut div = source_clock_hz / spi_clock_hz;
+    // Round up, so we always get a resulting SPI clock that is
+    // equal or less than the requested frequency.
+    let half_div =
+        u32::try_from(1 + u64::from(source_clock_hz - 1) / (u64::from(spi_clock_hz) * 2)).unwrap();
 
-    if source_clock_hz / div > spi_clock_hz {
-        div += 1;
-    }
+    // Make sure SCKDIV is between 0 and 255
+    // For some reason SCK starts to misbehave in between frames
+    // if half_div is less than 3.
+    let half_div = half_div.clamp(3, 128);
+    // Because half_div is in range [3,128], sckdiv is in range [4, 254].
+    let sckdiv = 2 * (half_div - 1);
 
-    // 0 <= div <= 255, and the true coefficient is really div + 2
-    let div = div.saturating_sub(2).clamp(0, 255);
-    ral::write_reg!(
-        ral::lpspi,
-        reg,
-        CCR,
-        SCKDIV: div,
-        // Both of these delays are arbitrary choices, and they should
-        // probably be configurable by the end-user.
-        DBT: div / 2,
-        SCKPCS: 0x1F,
-        PCSSCK: 0x1F
+    ral::write_reg!(ral::lpspi, reg, CCR,
+        // Delay between two clock transitions of two consecutive transfers
+        // is exactly sckdiv/2, which causes the transfer to be seamless.
+        DBT: half_div - 1,
+        // Add one sckdiv/2 setup and hold time before and after the transfer,
+        // to make sure the signal is stable at sample time
+        PCSSCK: half_div - 1,
+        SCKPCS: half_div - 1,
+        SCKDIV: sckdiv
     );
 }
 

--- a/src/common/lpspi.rs
+++ b/src/common/lpspi.rs
@@ -462,6 +462,11 @@ impl<P, const N: u8> Lpspi<P, N> {
     }
 
     /// Enable (`true`) or disable (`false`) the peripheral.
+    ///
+    /// Note that disabling does not take effect immediately; instead the
+    /// peripheral finishes the current transfer and then disables itself.
+    /// It is required to check [`is_enabled()`](Self::is_enabled) repeatedly until the
+    /// peripheral is actually disabled.
     pub fn set_enable(&mut self, enable: bool) {
         ral::modify_reg!(ral::lpspi, self.lpspi, CR, MEN: enable as u32)
     }


### PR DESCRIPTION
These are most of the non-breaking changes proposed in #149. I extracted them so that we could test and release them with today's driver. Unless there's concern, I plan to publish these within the 0.5 releases.