### PR TITLE
Fix warnings detected in upcoming toolchains

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -36,9 +36,25 @@ fn features_chip() -> HashSet<String> {
     features_10xx().into_iter().chain(features_11xx()).collect()
 }
 
+fn emit_cfg_checks<F>(cfg: &str, values: impl IntoIterator<Item = F>)
+where
+    F: std::fmt::Display,
+{
+    let quoted: Vec<String> = values
+        .into_iter()
+        .map(|value| format!("\"{}\"", value))
+        .collect();
+    let joined = quoted.join(", ");
+    // Single ":" permitted for backwards compatibility.
+    println!("cargo:rustc-check-cfg=cfg({cfg}, values({joined}))");
+}
+
 fn main() {
     let all_features = features_enabled();
     let feat_chip: HashSet<_> = features_chip();
+
+    emit_cfg_checks("chip", feat_chip.iter());
+    emit_cfg_checks("family", ["none", "imxrt10xx", "imxrt11xx"]);
 
     let enabled_chip: Vec<_> = all_features.intersection(&feat_chip).collect();
     assert!(

--- a/src/common/lpuart.rs
+++ b/src/common/lpuart.rs
@@ -588,7 +588,7 @@ impl Baud {
             }
         }
 
-        let mut err = u32::max_value();
+        let mut err = u32::MAX;
         let mut best_osr = 0;
         let mut best_sbr = 0;
 


### PR DESCRIPTION
Future Rust toolchains will warn about unknown cfgs and introduce more clippy warnings. This PR eagerly fixes those warnings. See commits for more information.