### PR TITLE
Update examples to RTIC v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ codegen-units = 256
 cortex-m = "0.7"
 imxrt-rt = { workspace = true }
 menu = "0.3.2"
-cortex-m-rtic = "1.0"
+rtic = { version = "2.0", features = ["thumbv7-backend"] }
 log = "0.4"
 defmt = "0.3"
 pin-utils = "0.1"

--- a/examples/rtic_defmt_rtt.rs
+++ b/examples/rtic_defmt_rtt.rs
@@ -33,7 +33,7 @@ mod app {
     struct Shared {}
 
     #[init]
-    fn init(cx: init::Context) -> (Shared, Local, init::Monotonics) {
+    fn init(cx: init::Context) -> (Shared, Local) {
         let mut cortex_m = cx.core;
         let (
             board::Common {
@@ -50,7 +50,7 @@ mod app {
         make_log.set_interrupt_enable(true);
         make_log.enable();
 
-        (Shared {}, Local { led, make_log }, init::Monotonics())
+        (Shared {}, Local { led, make_log })
     }
 
     #[task(binds = BOARD_PIT, local = [led, make_log, counter: u32 = 0], priority = 1)]
@@ -59,6 +59,7 @@ mod app {
             make_log,
             led,
             counter,
+            ..
         } = cx.local;
 
         // Is it time for us to send a new log message?

--- a/examples/rtic_dma_uart.rs
+++ b/examples/rtic_dma_uart.rs
@@ -34,7 +34,7 @@ mod app {
     }
 
     #[init(local = [buf: [u8; 32] = [0; 32]])]
-    fn init(cx: init::Context) -> (Shared, Local, init::Monotonics) {
+    fn init(cx: init::Context) -> (Shared, Local) {
         let (
             board::Common { mut dma, .. },
             board::Specifics {
@@ -58,7 +58,6 @@ mod app {
                 buffer: cx.local.buf,
                 state: State::Receiving,
             },
-            init::Monotonics(),
         )
     }
 
@@ -70,6 +69,7 @@ mod app {
             state,
             buffer,
             console,
+            ..
         } = cx.local;
 
         while channel.is_interrupt() {

--- a/examples/rtic_gpio_input.rs
+++ b/examples/rtic_gpio_input.rs
@@ -23,7 +23,7 @@ mod app {
     }
 
     #[init]
-    fn init(_: init::Context) -> (Shared, Local, init::Monotonics) {
+    fn init(_: init::Context) -> (Shared, Local) {
         let (
             board::Common {
                 pit: (_, _, pit, _),
@@ -40,7 +40,7 @@ mod app {
         let delay = BlockingPit::from_pit(pit);
         let button_port = ports.button_mut();
         button_port.set_interrupt(&button, Some(Trigger::FallingEdge));
-        (Shared {}, Local { led, button, delay }, init::Monotonics())
+        (Shared {}, Local { led, button, delay })
     }
 
     #[task(binds = BOARD_BUTTON, local = [led, delay, button])]

--- a/examples/rtic_gpt.rs
+++ b/examples/rtic_gpt.rs
@@ -33,7 +33,7 @@ mod app {
     }
 
     #[init]
-    fn init(_: init::Context) -> (Shared, Local, init::Monotonics) {
+    fn init(_: init::Context) -> (Shared, Local) {
         let (
             board::Common {
                 mut gpt1, mut gpt2, ..
@@ -44,7 +44,7 @@ mod app {
         init_gpt(&mut gpt2, GPT2_DELAY_MS);
 
         gpt1.enable();
-        (Shared { led, gpt1, gpt2 }, Local {}, init::Monotonics())
+        (Shared { led, gpt1, gpt2 }, Local {})
     }
 
     #[task(binds = BOARD_GPT1, shared = [led, gpt1, gpt2])]

--- a/examples/rtic_logging.rs
+++ b/examples/rtic_logging.rs
@@ -63,7 +63,7 @@ mod app {
     }
 
     #[init]
-    fn init(cx: init::Context) -> (Shared, Local, init::Monotonics) {
+    fn init(cx: init::Context) -> (Shared, Local) {
         let mut cortex_m = cx.core;
         let (
             board::Common {
@@ -112,7 +112,6 @@ mod app {
                 poll_log,
                 make_log,
             },
-            init::Monotonics(),
         )
     }
 
@@ -141,7 +140,7 @@ mod app {
 
     /// Actually performs the poll call.
     #[task(shared = [poller], priority = 2)]
-    fn poll_logger(mut cx: poll_logger::Context) {
+    async fn poll_logger(mut cx: poll_logger::Context) {
         cx.shared.poller.lock(|poller| poller.poll());
     }
 
@@ -152,6 +151,7 @@ mod app {
             make_log,
             led,
             counter,
+            ..
         } = cx.local;
 
         // Is it time for us to poll the logger?

--- a/examples/rtic_pit.rs
+++ b/examples/rtic_pit.rs
@@ -19,7 +19,7 @@ mod app {
     }
 
     #[init]
-    fn init(_: init::Context) -> (Shared, Local, init::Monotonics) {
+    fn init(_: init::Context) -> (Shared, Local) {
         let (
             board::Common {
                 pit: (_, _, mut pit, _),
@@ -30,7 +30,7 @@ mod app {
         pit.set_interrupt_enable(true);
         pit.set_load_timer_value(PIT_DELAY_MS);
         pit.enable();
-        (Shared {}, Local { led, pit }, init::Monotonics())
+        (Shared {}, Local { led, pit })
     }
 
     #[task(binds = BOARD_PIT, local = [led, pit])]

--- a/examples/rtic_pwm.rs
+++ b/examples/rtic_pwm.rs
@@ -26,7 +26,7 @@ mod app {
     }
 
     #[init]
-    fn init(_: init::Context) -> (Shared, Local, init::Monotonics) {
+    fn init(_: init::Context) -> (Shared, Local) {
         let (
             _,
             board::Specifics {
@@ -54,7 +54,7 @@ mod app {
         submodule.set_load_ok(&mut module);
         submodule.set_running(&mut module, true);
 
-        (Shared {}, Local { led, submodule }, init::Monotonics())
+        (Shared {}, Local { led, submodule })
     }
 
     #[task(binds = BOARD_PWM, local = [led, submodule, counter: u32 = 0])]

--- a/examples/rtic_spi.rs
+++ b/examples/rtic_spi.rs
@@ -23,7 +23,7 @@ mod app {
     struct Shared {}
 
     #[init]
-    fn init(_: init::Context) -> (Shared, Local, init::Monotonics) {
+    fn init(_: init::Context) -> (Shared, Local) {
         let (_, board::Specifics { mut spi, .. }) = board::new();
         // Trigger when the TX FIFO is empty.
         spi.set_watermark(Direction::Tx, 0);
@@ -32,12 +32,12 @@ mod app {
         // Starts the I/O as soon as we're done initializing, since
         // the TX FIFO is empty.
         spi.set_interrupts(Interrupts::TRANSMIT_DATA);
-        (Shared {}, Local { spi }, init::Monotonics())
+        (Shared {}, Local { spi })
     }
 
     #[task(binds = BOARD_SPI, local = [spi])]
     fn spi_interrupt(cx: spi_interrupt::Context) {
-        let spi_interrupt::LocalResources { spi } = cx.local;
+        let spi_interrupt::LocalResources { spi, .. } = cx.local;
 
         let status = spi.status();
         spi.clear_status(Status::TRANSMIT_DATA | Status::RECEIVE_DATA);

--- a/examples/rtic_spi_blocking.rs
+++ b/examples/rtic_spi_blocking.rs
@@ -26,7 +26,7 @@ mod app {
     struct Shared {}
 
     #[init]
-    fn init(_: init::Context) -> (Shared, Local, init::Monotonics) {
+    fn init(_: init::Context) -> (Shared, Local) {
         let (
             board::Common {
                 pit: (_, _, pit, _),
@@ -34,7 +34,7 @@ mod app {
             },
             board::Specifics { spi, .. },
         ) = board::new();
-        (Shared {}, Local { spi, pit }, init::Monotonics())
+        (Shared {}, Local { spi, pit })
     }
 
     #[idle(local = [spi, pit])]

--- a/examples/rtic_spi_controller.rs
+++ b/examples/rtic_spi_controller.rs
@@ -37,7 +37,7 @@ mod app {
     }
 
     #[init]
-    fn init(_: init::Context) -> (Shared, Local, init::Monotonics) {
+    fn init(_: init::Context) -> (Shared, Local) {
         let (
             board::Common {
                 pit: (_, _, mut pit, _),
@@ -51,13 +51,11 @@ mod app {
         pit.enable();
 
         spi.set_bit_order(BIT_ORDER);
-
         (
             Shared {
                 errors: AtomicU32::new(0),
             },
             Local { spi, pit },
-            init::Monotonics(),
         )
     }
 

--- a/examples/rtic_spi_peripheral.rs
+++ b/examples/rtic_spi_peripheral.rs
@@ -29,7 +29,7 @@ mod app {
     const BIT_ORDER: BitOrder = BitOrder::Msb;
 
     #[init]
-    fn init(_: init::Context) -> (Shared, Local, init::Monotonics) {
+    fn init(_: init::Context) -> (Shared, Local) {
         let (_, board::Specifics { mut spi, .. }) = board::new();
 
         spi.disabled(|spi| spi.set_peripheral_enable(true));
@@ -48,7 +48,7 @@ mod app {
         spi.set_watermark(Direction::Rx, 1);
         spi.set_interrupts(Interrupts::RECEIVE_DATA);
 
-        (Shared {}, Local { spi }, init::Monotonics())
+        (Shared {}, Local { spi })
     }
 
     #[task(binds=BOARD_SPI, local = [spi])]

--- a/examples/rtic_uart.rs
+++ b/examples/rtic_uart.rs
@@ -33,7 +33,7 @@ mod app {
     struct Shared {}
 
     #[init]
-    fn init(_: init::Context) -> (Shared, Local, init::Monotonics) {
+    fn init(_: init::Context) -> (Shared, Local) {
         let (
             _,
             board::Specifics {
@@ -53,7 +53,7 @@ mod app {
             // Interrupt when we receive a byte.
             console.set_interrupts(lpuart::Interrupts::RECEIVE_FULL);
         });
-        (Shared {}, Local { led, console }, init::Monotonics())
+        (Shared {}, Local { led, console })
     }
 
     #[task(binds = BOARD_CONSOLE, local = [led, console])]

--- a/examples/rtic_usb_keypress.rs
+++ b/examples/rtic_usb_keypress.rs
@@ -66,7 +66,7 @@ mod app {
     struct Shared {}
 
     #[init(local = [bus: Option<UsbBusAllocator<Bus>> = None])]
-    fn init(ctx: init::Context) -> (Shared, Local, init::Monotonics) {
+    fn init(ctx: init::Context) -> (Shared, Local) {
         let (
             board::Common {
                 pit: (mut timer, _, _, _),
@@ -123,7 +123,6 @@ mod app {
                 timer,
                 message: MESSAGE.iter().cycle(),
             },
-            init::Monotonics(),
         )
     }
 
@@ -144,6 +143,7 @@ mod app {
             led,
             configured,
             message,
+            ..
         } = ctx.local;
 
         device.poll(&mut [class]);

--- a/examples/rtic_usb_mouse.rs
+++ b/examples/rtic_usb_mouse.rs
@@ -61,7 +61,7 @@ mod app {
     struct Shared {}
 
     #[init(local = [bus: Option<UsbBusAllocator<Bus>> = None])]
-    fn init(ctx: init::Context) -> (Shared, Local, init::Monotonics) {
+    fn init(ctx: init::Context) -> (Shared, Local) {
         let (
             board::Common {
                 pit: (mut timer, _, _, _),
@@ -117,7 +117,6 @@ mod app {
                 poller,
                 timer,
             },
-            init::Monotonics(),
         )
     }
 
@@ -137,6 +136,7 @@ mod app {
             device,
             led,
             configured,
+            ..
         } = ctx.local;
 
         device.poll(&mut [class]);

--- a/examples/rtic_usb_serial.rs
+++ b/examples/rtic_usb_serial.rs
@@ -74,7 +74,7 @@ mod app {
     struct Shared {}
 
     #[init(local = [bus: Option<UsbBusAllocator<Bus>> = None])]
-    fn init(ctx: init::Context) -> (Shared, Local, init::Monotonics) {
+    fn init(ctx: init::Context) -> (Shared, Local) {
         let (
             board::Common {
                 pit: (mut timer, _, _, _),
@@ -119,7 +119,6 @@ mod app {
                 poller,
                 timer,
             },
-            init::Monotonics(),
         )
     }
 
@@ -139,6 +138,7 @@ mod app {
             device,
             configured,
             led,
+            ..
         } = ctx.local;
 
         if device.poll(&mut [class]) {

--- a/examples/rtic_usb_test_class.rs
+++ b/examples/rtic_usb_test_class.rs
@@ -67,7 +67,7 @@ mod app {
     struct Shared {}
 
     #[init(local = [bus: Option<UsbBusAllocator<Bus>> = None])]
-    fn init(ctx: init::Context) -> (Shared, Local, init::Monotonics) {
+    fn init(ctx: init::Context) -> (Shared, Local) {
         let (
             board::Common {
                 pit: (mut timer, _, _, _),
@@ -107,7 +107,6 @@ mod app {
                 poller,
                 timer,
             },
-            init::Monotonics(),
         )
     }
 
@@ -126,6 +125,7 @@ mod app {
             class,
             device,
             configured,
+            ..
         } = ctx.local;
 
         if device.poll(&mut [class]) {


### PR DESCRIPTION
The new framework has support for async tasks. It might be helpful for demonstrating async drivers, or for users who are comparing RTIC's latest documentation against our examples.

This is a minimal migration, and it's not trying to change any example's behavior. Let me know if you notice something different.

Tested on a 1010EVK using the `_pit`, `_defmt_rtt`, and `_logging` examples.  Also tested `_rtic_controller` on an 1170EVK, and `_rtic_peripheral` on a 1010EVK.