### PR TITLE
Increase imxrt-log default bulk MPS to 512

### DIFF
--- a/logging/CHANGELOG.md
+++ b/logging/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Increase the USB bulk max packet size (MPS) from 64 to 512. This is required
+for USB high-speed enumeration on some hosts. This adds 896 extra bytes to
+your firmware image.
+
 ## [0.1.1] 2023-03-14
 
 Read the bulk OUT endpoint in the USB device logger. This resolves some poor

--- a/logging/build.rs
+++ b/logging/build.rs
@@ -30,7 +30,7 @@ fn handle_usb_speed(file: &mut dyn Write) -> Result<bool, Error> {
 }
 fn handle_usb_bulk_speed_mps(file: &mut dyn Write, is_high_speed: bool) -> Result<(), Error> {
     const ALLOWED_MPS: &[usize] = &[8, 16, 32, 64, 512];
-    let mps = env::var("IMXRT_LOG_USB_BULK_MPS").unwrap_or_else(|_| "64".into());
+    let mps = env::var("IMXRT_LOG_USB_BULK_MPS").unwrap_or_else(|_| "512".into());
     let mps: usize = mps.parse().map_err(|err| -> Error {
         format!("{err:?} when trying to parse IMXRT_LOG_USB_BULK_MPS={mps}").into()
     })?;
@@ -39,6 +39,8 @@ fn handle_usb_bulk_speed_mps(file: &mut dyn Write, is_high_speed: bool) -> Resul
     }
     if !is_high_speed && mps == 512 {
         return Err("Bulk MPS of 512 does not work with full-speed USB devices. Either pick a different MPS, or configure a high-speed USB device".into());
+    } else if is_high_speed && mps != 512 {
+        return Err("High-speed USB devices must use a 512 byte MPS.".into());
     }
     writeln!(file, "\t#[cfg(feature = \"usbd\")]")?;
     writeln!(file, "\tpub const USB_BULK_MPS: usize = {mps};")?;

--- a/logging/src/lib.rs
+++ b/logging/src/lib.rs
@@ -105,9 +105,8 @@
 //! can help with this.
 //!
 //! By default, the initialization routine configures a high-speed USB device with
-//! a 64 byte bulk endpoint max packet size. You can change these settings with
-//! build-time environment variables, discussed later. The smaller max packet size
-//! reduces the size of the intermediate buffer required for the USB backend.
+//! a 512 byte bulk endpoint max packet size. You can change these settings with
+//! build-time environment variables, discussed later.
 //!
 //! _Interrupts_. If you enable interrupts (see [`Interrupts`]), the USB device
 //! controller asserts its interrupt when each transfer completes. It also enables
@@ -222,7 +221,7 @@
 //!
 //! | Environment variable           | Description                                               | Default value | Accepted values           |
 //! | ------------------------------ | --------------------------------------------------------- | ------------- | ------------------------- |
-//! | `IMXRT_LOG_USB_BULK_MPS`       | Bulk endpoint max packet size, in bytes.                  |      64       | One of 8, 16, 32, 64, 512 |
+//! | `IMXRT_LOG_USB_BULK_MPS`       | Bulk endpoint max packet size, in bytes.                  |     512       | One of 8, 16, 32, 64, 512 |
 //! | `IMXRT_LOG_USB_SPEED`          | Specify a high (USB2) or full (USB 1.1) speed USB device. |    HIGH       | Either `HIGH` or `FULL`   |
 //! | `IMXRT_LOG_BUFFER_SIZE`        | Specify the log message buffer size, in bytes.            |    1024       | An integer power of two   |
 //!
@@ -230,7 +229,8 @@
 //!
 //! - `IMXRT_LOG_USB_*` are always permitted. If `usbd` is disabled, then `IMXRT_LOG_USB_*`
 //!    configurations do nothing.
-//! - If `IMXRT_LOG_USB_SPEED=FULL`, then `IMXRT_LOG_USB_BULK_MPS` cannot be 512.
+//! - If `IMXRT_LOG_USB_SPEED=FULL`, then `IMXRT_LOG_USB_BULK_MPS` cannot be 512. On the other hand,
+//!   if `IMXRT_LOG_USB_SPEED=HIGH`, then `IMXRT_LOG_USB_BULK_MPS` must be 512.
 //! - Both `IMXRT_LOG_USB_BULK_MPS` and `IMXRT_LOG_BUFFER_SIZE` affect internally-managed buffer
 //!   sizes. If space is tight, reduces these numbers to reclaim memory.
 //!
@@ -425,7 +425,7 @@ mod tests {
 
     #[test]
     fn default_configs() {
-        assert_eq!(crate::config::USB_BULK_MPS, 64);
+        assert_eq!(crate::config::USB_BULK_MPS, 512);
         assert_eq!(crate::config::USB_SPEED, imxrt_usbd::Speed::High);
         assert_eq!(crate::config::BUFFER_SIZE, 1024);
     }


### PR DESCRIPTION
[Community troubleshooting on Windows](https://github.com/mciantyre/teensy4-rs/issues/126) revealed that the USB device must use a bulk endpoint max packet size (MPS) of 512 bytes if the device is high speed. Since imxrt-log's USB back-end is already high-speed by default, this commit increases the default MPS to 512 bytes.

Tested using the rtic_logging and hal_logging examples on a Teensy 4. I've not tested against a Windows host, which is where this issue manifested.