### PR TITLE
Fix min-versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.5.5"
 version = "1.0"
 
 [dependencies.bitflags]
-version = "1.2"
+version = "1.3.1"
 
 [dependencies.fugit]
 version = "0.3"
@@ -39,7 +39,7 @@ features = ["async-await"]
 
 [dependencies.eh02]
 package = "embedded-hal"
-version = "0.2"
+version = "0.2.6"
 
 [dependencies.eh1]
 package = "embedded-hal"
@@ -99,7 +99,7 @@ eh02-unproven = []
 members = ["board", "logging"]
 
 [workspace.dependencies]
-imxrt-dma = "0.1"
+imxrt-dma = "0.1.1"
 imxrt-iomuxc = "0.2.1"
 imxrt-hal = { version = "0.5", path = "." }
 imxrt-log = { path = "logging", default-features = false, features = [
@@ -107,7 +107,7 @@ imxrt-log = { path = "logging", default-features = false, features = [
     "lpuart",
     "usbd",
 ] }
-imxrt-ral = "0.5"
+imxrt-ral = "0.5.4"
 imxrt-rt = "0.1"
 imxrt-usbd = "0.2"
 


### PR DESCRIPTION
I'm in the process of setting up a min-versions check in my crate, and it seems a bunch of versions are not specific enough in `imxrt-hal`.

It seems that `ral-registers` should be `0.1.2`. But I bumped it to `0.1.3` to allow trailing commas in the register accessor macros.

This should be a patch release as this only changes the patch versions of dependencies.

# Rationale

When performing a min-versions test, all packages get downgraded to their minimal possible semver version. That shows if all dependencies got upgraded properly in `Cargo.toml`.

In my case (talking about the CI of the crate `imxrt-uart-panic`), I need to specify the following dependendencies manually because they are incorrect in the `imxrt-hal` crate and dependencies:
```
imxrt-dma = { version = ">= 0.1.1", default-features = false }
ral-registers = { version = ">= 0.1.2", default-features = false }
embedded-hal = { version = "0.2.6", default-features = false }
bitflags = { version = "1.3.1", default-features = false }
```

This change depends on https://github.com/imxrt-rs/imxrt-ral/pull/47.