### PR TITLE
Block at end of LPI2C embedded-hal transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Add LPSPI low-level clock configuration APIs.
 - Add LPSPI `set_peripheral_enable` to configure the driver as a SPI peripheral.
 
+When the LPI2C driver concludes a transaction, it ensures that the controller
+is idle before returning.
+
 ## [0.5.5] 2024-05-27
 
 Add embedded-hal 1 implementations for the following drivers:

--- a/board/src/teensy4.rs
+++ b/board/src/teensy4.rs
@@ -60,12 +60,11 @@ pub type Spi = ();
 /// SPI peripheral.
 pub type Spi = hal::lpspi::Lpspi<SpiPins, 4>;
 
-pub type I2cPins = hal::lpi2c::Pins<
-    iomuxc::gpio_ad_b1::GPIO_AD_B1_07, // SCL, P16
-    iomuxc::gpio_ad_b1::GPIO_AD_B1_06, // SDA, P17
->;
+type I2cScl = iomuxc::gpio_ad_b1::GPIO_AD_B1_00; // P19
+type I2cSda = iomuxc::gpio_ad_b1::GPIO_AD_B1_01; // P18
+pub type I2cPins = hal::lpi2c::Pins<I2cScl, I2cSda>;
 
-pub type I2c = hal::lpi2c::Lpi2c<I2cPins, 3>;
+pub type I2c = hal::lpi2c::Lpi2c<I2cPins, 1>;
 
 /// PWM components.
 pub mod pwm {
@@ -165,12 +164,12 @@ impl Specifics {
         #[allow(clippy::let_unit_value)]
         let spi = ();
 
-        let lpi2c3 = unsafe { ral::lpi2c::LPI2C3::instance() };
+        let lpi2c1 = unsafe { ral::lpi2c::LPI2C1::instance() };
         let i2c = I2c::new(
-            lpi2c3,
+            lpi2c1,
             I2cPins {
-                scl: iomuxc.gpio_ad_b1.p07,
-                sda: iomuxc.gpio_ad_b1.p06,
+                scl: iomuxc.gpio_ad_b1.p00,
+                sda: iomuxc.gpio_ad_b1.p01,
             },
             &super::I2C_BAUD_RATE,
         );
@@ -243,8 +242,10 @@ fn configure_pins(
         .set_speed(iomuxc::Speed::Fast)
         .set_pull_keeper(Some(iomuxc::PullKeeper::Pullup22k));
 
-    iomuxc::configure(&mut gpio_ad_b1.p07, I2C_PIN_CONFIG);
-    iomuxc::configure(&mut gpio_ad_b1.p06, I2C_PIN_CONFIG);
+    let scl: &mut I2cScl = &mut gpio_ad_b1.p00;
+    iomuxc::configure(scl, I2C_PIN_CONFIG);
+    let sda: &mut I2cSda = &mut gpio_ad_b1.p01;
+    iomuxc::configure(sda, I2C_PIN_CONFIG);
 
     const BUTTON_CONFIG: iomuxc::Config = iomuxc::Config::zero()
         .set_pull_keeper(Some(iomuxc::PullKeeper::Pullup100k))


### PR DESCRIPTION
Wait for the controller to become idle before returning to the transaction caller. This is a stronger guarantee than waiting until the stop bit is sent, and it meets the EH1 interface requirements.

This commit still keeps the busy check at the start of the transactions. If the bus is busy due to another controller's activity, I don't think we should block the caller while the other controller uses the bus. The caller can implement a retry policy given the characteristics of their system. EH1 lets users handle this condition with a dedicated error kind.

Additionally, this commit keeps the FIFO flushes at the start of transactions, after the busy checks. This is intended to avoid surprises in case a user inserts a high-level transaction somewhere in their low-level command sequence.

I updated one of the I2C examples to blast a device through the eh02 interfaces. It behaved reasonably on a Teensy 4 setup.