### PR TITLE
Fix embedded-hal version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.5.5"
 version = "1.0"
 
 [dependencies.bitflags]
-version = "1.2"
+version = "1.3"
 
 [dependencies.fugit]
 version = "0.3"
@@ -39,7 +39,7 @@ features = ["async-await"]
 
 [dependencies.eh02]
 package = "embedded-hal"
-version = "0.2"
+version = "0.2.6"
 
 [dependencies.eh1]
 package = "embedded-hal"
@@ -53,6 +53,12 @@ version = "0.6.1"
 version = "0.5"
 default-features = false
 optional = true
+
+# This is an indirect dependency through imxrt-ral;
+# imxrt-ral depends on `ral-registers 0.1.0`,
+# but we are using newer features.
+[dependencies.ral-registers]
+version = "0.1.3"
 
 #######################
 # imxrt-rs dependencies


### PR DESCRIPTION
- Update `embedded-hal` to `0.2.6`:
  This crate uses `eh02::blocking::i2c::Operation`, which only exists for `embedded-hal 0.2.6` and upwards
- Update `bitflags` to `1.3`:
  This crate uses `.complement()` which only exists in `bitflags 1.3` and upwards
- Update `ral-registers` to `0.1.2`:
  This crate uses newer features from `ral-registers 0.1.2`