### PR TITLE
Update to imxrt-usbd 0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+**BREAKING** Update `imxrt-usbd` to 0.3. Users are required to update to
+`usb-device` 0.3 and its compatible dependencies.
+
 ## [0.5.6] 2024-07-05
 
 - Add LPSPI low-level clock configuration APIs.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ imxrt-log = { path = "logging", default-features = false, features = [
 ] }
 imxrt-ral = "0.5"
 imxrt-rt = "0.1"
-imxrt-usbd = "0.2"
+imxrt-usbd = "0.3"
 
 [workspace.package]
 repository = "https://github.com/imxrt-rs/imxrt-hal"
@@ -155,9 +155,9 @@ rtic = { version = "2.0", features = ["thumbv7-backend"] }
 log = "0.4"
 defmt = "0.3"
 pin-utils = "0.1"
-usb-device = { version = "0.2", features = ["test-class-high-speed"] }
-usbd-serial = "0.1"
-usbd-hid = "0.6"
+usb-device = { version = "0.3", features = ["test-class-high-speed"] }
+usbd-serial = "0.2"
+usbd-hid = "0.7"
 
 [target.'cfg(all(target_arch = "arm", target_os = "none"))'.dev-dependencies]
 board = { path = "board" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ defmt = "0.3"
 pin-utils = "0.1"
 usb-device = { version = "0.3", features = ["test-class-high-speed"] }
 usbd-serial = "0.2"
-usbd-hid = "0.7"
+usbd-hid = "0.8"
 
 [target.'cfg(all(target_arch = "arm", target_os = "none"))'.dev-dependencies]
 board = { path = "board" }

--- a/board/Cargo.toml
+++ b/board/Cargo.toml
@@ -30,6 +30,7 @@ default-features = false
 
 [dependencies.imxrt-usbd]
 workspace = true
+features = ["defmt-03"]
 
 [dependencies.cortex-m]
 version = "0.7"

--- a/board/build.rs
+++ b/board/build.rs
@@ -60,6 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         dtcm: 1,
                     })
                     .uninit(Memory::Dtcm)
+                    .stack_size(16 * 1024)
                     .build()?;
                 println!("cargo:rustc-cfg=board=\"imxrt1010evk\"");
                 println!("cargo:rustc-cfg=chip=\"imxrt1010\"");

--- a/examples/rtic_usb_keypress.rs
+++ b/examples/rtic_usb_keypress.rs
@@ -108,9 +108,11 @@ mod app {
         // device, bInterval is computed differently.
         let class = HIDClass::new(bus, KeyboardReport::desc(), 4);
         let device = UsbDeviceBuilder::new(bus, VID_PID)
-            .product(PRODUCT)
+            .strings(&[usb_device::device::StringDescriptors::default().product(PRODUCT)])
+            .unwrap()
             .device_class(usbd_serial::USB_CLASS_CDC)
             .max_packet_size_0(64)
+            .unwrap()
             .build();
 
         (

--- a/examples/rtic_usb_mouse.rs
+++ b/examples/rtic_usb_mouse.rs
@@ -103,9 +103,11 @@ mod app {
         // device, bInterval is computed differently.
         let class = HIDClass::new(bus, MouseReport::desc(), 4);
         let device = UsbDeviceBuilder::new(bus, VID_PID)
-            .product(PRODUCT)
+            .strings(&[usb_device::device::StringDescriptors::default().product(PRODUCT)])
+            .unwrap()
             .device_class(usbd_serial::USB_CLASS_CDC)
             .max_packet_size_0(64)
+            .unwrap()
             .build();
 
         (

--- a/examples/rtic_usb_serial.rs
+++ b/examples/rtic_usb_serial.rs
@@ -105,9 +105,11 @@ mod app {
         let bus = ctx.local.bus.insert(UsbBusAllocator::new(bus));
         let class = SerialPort::new(bus);
         let device = UsbDeviceBuilder::new(bus, VID_PID)
-            .product(PRODUCT)
+            .strings(&[usb_device::device::StringDescriptors::default().product(PRODUCT)])
+            .unwrap()
             .device_class(usbd_serial::USB_CLASS_CDC)
             .max_packet_size_0(64)
+            .unwrap()
             .build();
 
         (

--- a/examples/rtic_usb_test_class.rs
+++ b/examples/rtic_usb_test_class.rs
@@ -97,7 +97,11 @@ mod app {
 
         let bus = ctx.local.bus.insert(UsbBusAllocator::new(bus));
         let class = TestClass::new(bus);
-        let device = class.make_device_builder(bus).max_packet_size_0(64).build();
+        let device = class
+            .make_device_builder(bus)
+            .max_packet_size_0(64)
+            .unwrap()
+            .build();
 
         (
             Shared {},

--- a/logging/CHANGELOG.md
+++ b/logging/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+**BREAKING** Integrate breaking dependencies for the USB back-end:
+
+- `imxrt-usbd` 0.3
+- `usb-device` 0.3
+- `usbd-serial` 0.2
+
 ## [0.1.2] 2024-06-06
 
 Increase the USB bulk max packet size (MPS) from 64 to 512. This is required

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -23,11 +23,11 @@ version = "0.4"
 
 [dependencies.usb-device]
 optional = true
-version = "0.2"
+version = "0.3"
 
 [dependencies.usbd-serial]
 optional = true
-version = "0.1"
+version = "0.2"
 
 [dependencies.imxrt-hal]
 optional = true

--- a/logging/src/usbd.rs
+++ b/logging/src/usbd.rs
@@ -195,9 +195,11 @@ pub(crate) unsafe fn init<P: imxrt_usbd::Peripherals>(
 
     {
         let device = usb_device::device::UsbDeviceBuilder::new(bus, VID_PID)
-            .product(PRODUCT)
+            .strings(&[usb_device::device::StringDescriptors::default().product(PRODUCT)])
+            .unwrap()
             .device_class(usbd_serial::USB_CLASS_CDC)
             .max_packet_size_0(EP0_CONTROL_PACKET_SIZE as u8)
+            .unwrap()
             .build();
 
         // Not sure which endpoints the CDC ACM class will pick,


### PR DESCRIPTION
The update requires us to adopt usb-device 0.3 and its associated dependencies. All USB examples, including rtic_logging, worked as expected on a Teensy 4.0. We're still passing the usb-device TestClass test suite on both a Teensy 4 and a 1010EVK.