### PR TITLE
Patch usbd-hid-macros development dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,3 +204,7 @@ name = "rtic_defmt_rtt"
 [[example]]
 name = "hal_i2c_lcd1602"
 required-features = ["board/lcd1602"]
+
+[patch.crates-io.usbd-hid-macros]
+git = "https://github.com/imxrt-rs/usbd-hid.git"
+branch = "patch-imxrt-hal-0.5"


### PR DESCRIPTION
Our usbd-hid 0.6 development dependency no longer builds. See the upstream [issue tracker](https://github.com/twitchyliquid64/usbd-hid/issues/72) for details. This [affects](https://github.com/imxrt-rs/imxrt-hal/actions/runs/9957883319/job/27510926864#step:4:160) the USB HID examples we maintain in this repository.

This commit patches the development dependency so our examples still build. Note that this only affects examples tied to imxrt-hal 0.5; see #168 for a breaking change that also fixes the build.