### PR TITLE
Lpuart Baud Compute Bug

### DIFF
--- a/src/common/lpuart.rs
+++ b/src/common/lpuart.rs
@@ -593,8 +593,8 @@ impl Baud {
         let mut best_sbr = 0;
 
         let mut osr = 8;
-        let mut sbr = 1;
         while osr <= 32 {
+            let mut sbr = 1;
             while sbr < 8192 {
                 let b = source_clock_hz / (sbr * osr);
                 let e = max(baud, b) - min(baud, b);
@@ -1065,6 +1065,24 @@ mod tests {
         } else {
             assert_eq!(BAUD.osr, 8);
         }
+        assert!(!BAUD.bothedge);
+    }
+
+    #[test]
+    fn non_default_sbr_baud() {
+        // Assume the 24MHz XTAL clock.
+        const UART_CLOCK_HZ: u32 = 24_000_000;
+        // The best baud rate we can get is
+        const EXPECTED_BAUD: u32 = 9600;
+        // for a target baud of
+        const TARGET_BAUD: u32 = 9600;
+
+        const BAUD: Baud = Baud::compute(UART_CLOCK_HZ, TARGET_BAUD);
+
+        assert_eq!(BAUD.value(UART_CLOCK_HZ), EXPECTED_BAUD);
+
+        assert_eq!(BAUD.osr, 10, "OSR: {}", BAUD.osr);
+        assert_eq!(BAUD.sbr, 250, "SBR: {}", BAUD.sbr);
         assert!(!BAUD.bothedge);
     }
 

--- a/src/common/lpuart.rs
+++ b/src/common/lpuart.rs
@@ -592,7 +592,7 @@ impl Baud {
         let mut best_osr = 0;
         let mut best_sbr = 0;
 
-        let mut osr = 8;
+        let mut osr = if baud > 3_000_000 { 4 } else { 8 };
         while osr <= 32 {
             let mut sbr = 1;
             while sbr < 8192 {
@@ -1084,6 +1084,24 @@ mod tests {
         assert_eq!(BAUD.osr, 10, "OSR: {}", BAUD.osr);
         assert_eq!(BAUD.sbr, 250, "SBR: {}", BAUD.sbr);
         assert!(!BAUD.bothedge);
+    }
+
+    #[test]
+    fn max_baud() {
+        // Assume the 24MHz XTAL clock.
+        const UART_CLOCK_HZ: u32 = 24_000_000;
+        // The best baud rate we can get is
+        const EXPECTED_BAUD: u32 = 6_000_000;
+        // for a target baud of
+        const TARGET_BAUD: u32 = 6_000_000;
+
+        const BAUD: Baud = Baud::compute(UART_CLOCK_HZ, TARGET_BAUD);
+
+        assert_eq!(BAUD.value(UART_CLOCK_HZ), EXPECTED_BAUD);
+
+        assert_eq!(BAUD.osr, 4, "OSR: {}", BAUD.osr);
+        assert_eq!(BAUD.sbr, 1, "SBR: {}", BAUD.sbr);
+        assert!(BAUD.bothedge);
     }
 
     #[test]


### PR DESCRIPTION
From my understanding of the common::lpaurt::Baud::compute function, it is meant to test every oversampling rate from 8 to 32, and every modulo divisor from 1 to 8191.

The current code does not reset the modulo divisor value after comparing to an oversampling rate, leading to only one oversampling rate being tested. I've added a test that fails on the current code, but passes in the fixed code, highlighting the issue.

On a separate note, the oversampling rate is tested from 8 to 32, yet the minimum possible value is 4. I suspect that the author of the code found that sampling on both edges of the clock was unstable, or unfavorable for some reason, as this applies at oversampling rates <8. However, starting at the value of 8 limits possible baud rates to a maximum of 3MBd, while I've found higher values to be stable in communication between two Teensy 4.0s (albeit not tested with an oscilloscope). I've thus added a rudimentary fix, where the oversampling rate checking starts at a value of 4 instead of 8 when the baud rate is higher than 3MBd, however it seems simpler to always have it start at 4, so consider this and please state any concerns prior to merging.