### PR TITLE
Document unsafe interfaces, implementations

### DIFF
--- a/logging/src/defmt.rs
+++ b/logging/src/defmt.rs
@@ -104,6 +104,8 @@ mod frontend {
 #[defmt::global_logger]
 struct Logger;
 
+// Safety: we rely on a critical section acquire in order to meet the
+// defmt::Logger safety contract.
 unsafe impl defmt::Logger for Logger {
     fn acquire() {
         frontend::acquire(|producer, encoder| {
@@ -195,6 +197,8 @@ pub fn lpuart<P, const LPUART: u8>(
 
     critical_section::with(|_| {
         frontend::init(producer);
+        // Safety: "called once" requirement met by the buffer split, above.
+        // Only the first successful split flows into this call.
         unsafe { crate::lpuart::init(lpuart, dma_channel, consumer, interrupts) };
         Ok(crate::Poller::new(crate::lpuart::VTABLE))
     })

--- a/logging/src/lib.rs
+++ b/logging/src/lib.rs
@@ -253,7 +253,11 @@
 //! [log-docs]: https://docs.rs/log/0.4/log/
 
 #![no_std]
-#![warn(missing_docs, unsafe_op_in_unsafe_fn)]
+#![warn(
+    missing_docs,
+    unsafe_op_in_unsafe_fn,
+    clippy::undocumented_unsafe_blocks
+)]
 
 #[cfg(feature = "defmt")]
 pub mod defmt;

--- a/logging/src/lib.rs
+++ b/logging/src/lib.rs
@@ -256,7 +256,8 @@
 #![warn(
     missing_docs,
     unsafe_op_in_unsafe_fn,
-    clippy::undocumented_unsafe_blocks
+    clippy::undocumented_unsafe_blocks,
+    clippy::missing_safety_doc
 )]
 
 #[cfg(feature = "defmt")]

--- a/logging/src/lib.rs
+++ b/logging/src/lib.rs
@@ -377,6 +377,9 @@ impl Poller {
     /// in each transfer.
     #[inline]
     pub fn poll(&mut self) {
+        // Safety: poll() implementations can only be called from one execution
+        // context, to completion. Taking a &mut receiver ensures that this call
+        // isn't happening concurrently with itself.
         unsafe { (self.vtable.poll)() };
     }
 }

--- a/src/chip/dma.rs
+++ b/src/chip/dma.rs
@@ -83,6 +83,8 @@ use mappings::*;
 // LPUART
 use crate::lpuart;
 
+// Safety: a LPUART can support writes from a DMA engine into its data register.
+// The peripheral is static, so it's always a valid target for memory writes.
 unsafe impl<P, const N: u8> peripheral::Destination<u8> for lpuart::Lpuart<P, N> {
     fn destination_signal(&self) -> u32 {
         LPUART_DMA_TX_MAPPING[N as usize - 1]
@@ -98,6 +100,8 @@ unsafe impl<P, const N: u8> peripheral::Destination<u8> for lpuart::Lpuart<P, N>
     }
 }
 
+// Safety: a LPUART can support reads performed by a DMA engine from its data
+// register. The peripheral is static and always valid for reading.
 unsafe impl<P, const N: u8> peripheral::Source<u8> for lpuart::Lpuart<P, N> {
     fn source_signal(&self) -> u32 {
         LPUART_DMA_RX_MAPPING[N as usize - 1]
@@ -141,6 +145,8 @@ impl<P, const N: u8> lpuart::Lpuart<P, N> {
 // LPSPI
 use crate::lpspi;
 
+// Safety: a LPSPI can provide data for a DMA transfer. Its receive data register
+// points to static memory.
 unsafe impl<P, const N: u8> peripheral::Source<u32> for lpspi::Lpspi<P, N> {
     fn source_signal(&self) -> u32 {
         LPSPI_DMA_RX_MAPPING[N as usize - 1]
@@ -156,6 +162,8 @@ unsafe impl<P, const N: u8> peripheral::Source<u32> for lpspi::Lpspi<P, N> {
     }
 }
 
+// Safety: a LPSPI can receive data for a DMA transfer. Its transmit data register
+// points to static memory.
 unsafe impl<P, const N: u8> peripheral::Destination<u32> for lpspi::Lpspi<P, N> {
     fn destination_signal(&self) -> u32 {
         LPSPI_DMA_TX_MAPPING[N as usize - 1]
@@ -171,6 +179,8 @@ unsafe impl<P, const N: u8> peripheral::Destination<u32> for lpspi::Lpspi<P, N> 
     }
 }
 
+// Safety: a LPSPI can perform bi-directional I/O from a single buffer. Reads from
+// the buffer are always performed before writes.
 unsafe impl<P, const N: u8> peripheral::Bidirectional<u32> for lpspi::Lpspi<P, N> {}
 
 impl<P, const N: u8> lpspi::Lpspi<P, N> {
@@ -242,6 +252,8 @@ impl<P, const N: u8> lpspi::Lpspi<P, N> {
 use crate::adc;
 
 #[cfg(family = "imxrt10xx")]
+// Safety: an ADC source adapter points to a static register that's always valid
+// for reads.
 unsafe impl<P, const N: u8> peripheral::Source<u16> for adc::DmaSource<P, N> {
     fn source_signal(&self) -> u32 {
         ADC_DMA_RX_MAPPING[if N == ral::SOLE_INSTANCE {

--- a/src/chip/imxrt10xx/tempmon.rs
+++ b/src/chip/imxrt10xx/tempmon.rs
@@ -133,7 +133,8 @@ pub struct TempMon {
 impl TempMon {
     /// Initialize and create the temperature monitor.
     pub fn new(tempmon: ral::tempmon::TEMPMON) -> Self {
-        // this operation is safe. This value is read-only and set by the manufacturer.
+        // Safety: This value is read-only and set by the manufacturer. imxrt-ral
+        // is constructed to always point at a valid OCOTP instance.
         let calibration = unsafe { ral::read_reg!(ral::ocotp, OCOTP, ANA1) };
 
         // The ral doesn't provide direct access to the values.

--- a/src/common/flexpwm/ral.rs
+++ b/src/common/flexpwm/ral.rs
@@ -182,7 +182,7 @@ pub type Submodules<const N: u8> = (
 );
 
 /// Shorthand to allocate four submodules for PWM `N`.
-pub fn submodules<const N: u8>(pwm: &crate::ral::pwm::Instance<N>) -> Submodules<N> {
+pub(crate) fn submodules<const N: u8>(pwm: &crate::ral::pwm::Instance<N>) -> Submodules<N> {
     (
         Submodule(core::ptr::addr_of!(pwm.SM[0]) as *const _),
         Submodule(core::ptr::addr_of!(pwm.SM[1]) as *const _),

--- a/src/common/flexpwm/ral.rs
+++ b/src/common/flexpwm/ral.rs
@@ -167,10 +167,17 @@ impl<const N: u8, const M: u8> ::core::ops::Deref for Submodule<N, M> {
     type Target = RegisterBlock;
     #[inline]
     fn deref(&self) -> &Self::Target {
+        // Safety: Pointer is valid per `submodules` implementation, below.
+        // Layout of RegisterBlock is checked against the reference manual.
+        // The size of RegisterBlock is correct, meaning that we never access
+        // beyond the memory of the original pointer.
         unsafe { &*self.0 }
     }
 }
 
+// Safety: The pointer wrapped by Submodule points into static MMIO registers;
+// see `submodules` for specifics. That owned pointer can be sent across execution
+// contexts.
 unsafe impl<const N: u8, const M: u8> Send for Submodule<N, M> {}
 
 /// Four submodules for the `N`th PWM instance.

--- a/src/common/lpspi.rs
+++ b/src/common/lpspi.rs
@@ -1347,7 +1347,7 @@ trait ReceiveData {
 struct TransmitBuffer<'a, W> {
     /// The read position.
     ptr: *const W,
-    /// One past the end of the buffer.
+    /// At the end of the buffer.
     end: *const W,
     _buffer: PhantomData<&'a [W]>,
 }
@@ -1363,11 +1363,13 @@ where
 
     /// # Safety
     ///
-    /// `ptr + len` must be in bounds, or one past the end of the
+    /// `ptr + len` must be in bounds, or at the end of the
     /// allocation.
     unsafe fn from_raw(ptr: *const W, len: usize) -> Self {
         Self {
             ptr,
+            // Safety: caller upholds contract that ptr + len
+            // must be in bounds, or at the end.
             end: unsafe { ptr.add(len) },
             _buffer: PhantomData,
         }
@@ -1399,7 +1401,7 @@ where
 struct ReceiveBuffer<'a, W> {
     /// The write position.
     ptr: *mut W,
-    /// One past the end of the buffer.
+    /// At the end of the buffer.
     end: *const W,
     _buffer: PhantomData<&'a [W]>,
 }
@@ -1416,11 +1418,13 @@ where
 
     /// # Safety
     ///
-    /// `ptr + len` must be in bounds, or one past the end of the
+    /// `ptr + len` must be in bounds, or at the end of the
     /// allocation.
     unsafe fn from_raw(ptr: *mut W, len: usize) -> Self {
         Self {
             ptr,
+            // Safety: caller upholds contract that ptr + len
+            // must be in bounds, or at the end.
             end: unsafe { ptr.cast_const().add(len) },
             _buffer: PhantomData,
         }

--- a/src/common/pit.rs
+++ b/src/common/pit.rs
@@ -83,6 +83,9 @@ pub fn new<const N: u8>(pit: crate::ral::pit::Instance<N>) -> Channels {
     crate::ral::write_reg!(crate::ral::pit::timer, &pit.TIMER[2], TCTRL, 0);
     crate::ral::write_reg!(crate::ral::pit::timer, &pit.TIMER[3], TCTRL, 0);
 
+    // Safety: we own the larger PIT peripheral instance. The caller
+    // (or the user who fabricated the larger PIT instance) ensures
+    // that we're not aliasing that peripheral.
     unsafe {
         (
             Pit::new(&pit),
@@ -256,6 +259,9 @@ impl<const CHAN: u8> Pit<CHAN> {
     }
 }
 
+// Safety: reference to static MMIO can be moved across execution contexts.
+// Study of this module reveals that the safe API splits the larger PIT
+// peripheral instance into separate, non-aliasing channels.
 unsafe impl<const CHAN: u8> Send for Pit<CHAN> {}
 
 /// Two chained PIT timer channels.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,8 @@
 #![warn(
     missing_docs,
     unsafe_op_in_unsafe_fn,
-    clippy::undocumented_unsafe_blocks
+    clippy::undocumented_unsafe_blocks,
+    clippy::missing_safety_doc
 )]
 
 use imxrt_ral as ral;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,11 @@
 //! `"unproven"` feature enabled in embedded-hal 0.2.
 
 #![no_std]
-#![warn(missing_docs, unsafe_op_in_unsafe_fn)]
+#![warn(
+    missing_docs,
+    unsafe_op_in_unsafe_fn,
+    clippy::undocumented_unsafe_blocks
+)]
 
 use imxrt_ral as ral;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,6 +261,10 @@ pub mod usbd {
         pub usbphy: ral::usbphy::Instance<N>,
     }
 
+    // Safety: pointers to USB peripheral blocks come from
+    // imxrt-ral, which provides correct addresses. We take
+    // ownership of the peripheral instances, preventing others
+    // from aliasing the peripherals.
     unsafe impl<const N: u8> Peripherals for Instances<N> {
         fn usb(&self) -> *const () {
             (&*self.usb as *const ral::usb::RegisterBlock).cast()


### PR DESCRIPTION
The PR adds safety notes to all `unsafe` blocks within the HAL and logging package. The PR also ensures that any unsafe public interface is also documented. See commit messages for details.