### PR TITLE
Remove static muts from logging package

### DIFF
--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 [dependencies]
 critical-section = "1"
 bbqueue = "0.5"
+static_cell = "2.1.0"
 
 [dependencies.defmt]
 optional = true

--- a/logging/src/log.rs
+++ b/logging/src/log.rs
@@ -96,15 +96,12 @@ pub fn usbd_with_config<P: imxrt_usbd::Peripherals>(
         Err(_) => return Err(crate::AlreadySetError::new(peripherals)),
     };
 
-    // Safety: both can only be called once. We use try_split
-    // (above) to meet that requirement. If that method is called
-    // more than once, subsequent calls are an error.
-    critical_section::with(|_| unsafe {
+    critical_section::with(|_| {
         if frontend::init(producer, frontend_config).is_err() {
             return Err(crate::AlreadySetError::new(peripherals));
         }
-        crate::usbd::init(peripherals, interrupts, consumer, backend_config);
-        Ok(Poller::new(crate::usbd::VTABLE))
+        let backend = crate::usbd::init(peripherals, interrupts, consumer, backend_config);
+        Ok(Poller::new(backend))
     })
 }
 
@@ -140,14 +137,12 @@ pub fn lpuart_with_config<P, const LPUART: u8>(
         Err(_) => return Err(crate::AlreadySetError::new((lpuart, dma_channel))),
     };
 
-    // Safety: all of this can only happen once. We use try_split
-    // to meet that requirement.
-    critical_section::with(|_| unsafe {
+    critical_section::with(|_| {
         if frontend::init(producer, frontend_config).is_err() {
             return Err(crate::AlreadySetError::new((lpuart, dma_channel)));
         }
-        crate::lpuart::init(lpuart, dma_channel, consumer, interrupts);
-        Ok(Poller::new(crate::lpuart::VTABLE))
+        let backend = crate::lpuart::init(lpuart, dma_channel, consumer, interrupts);
+        Ok(Poller::new(backend))
     })
 }
 


### PR DESCRIPTION
Upcoming clippy versions have more aggressive warnings about static mut, so I'm removing them from the logging package. The defmt frontend uses a custom static with interior mutability. The implementation is otherwise the same.

I refactored the rest of the package to use `&'static mut`s produced by the static_cell package. This lets us remove the explicit uninitialized memory and the mutable statics. The details are unchanged.

Tested the rtic_logging example on an 1170EVK: logging frontend with both backends, and the defmt frontend with just the LPUART frontend.