### PR TITLE
Fix LPSPI word unpacking in receive operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 
 **BREAKING** `LpspiError::{Busy, NoData}` are removed as possible LPSPI errors.
 
+Correct LPSPI receive operations. Previously, `u8` and `u16` elements received
+by the driver were returned out of order to the user. This release fixes the
+ordering. If you were correcting this behavior in application code, you'll need
+to remove that behavior before adopting this fix.
+
 ## [0.5.8] 2024-11-01
 
 Fix LPUART baud rate computation, ensuring updates to SBR when evaluating other


### PR DESCRIPTION
LPSPI receive operations are reversing byte and half-word elements when they place data in the caller's buffer. We can show this using the revised loopback tests on an older LPSPI driver.

The unpacking routines need to consider the frame boundary and the bit order when they deconstruct the 32 bit LPSPI word.