### PR TITLE
Update imxrt dependencies, package versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 **BREAKING** Update `imxrt-usbd` to 0.3. Users are required to update to
 `usb-device` 0.3 and its compatible dependencies.
 
+**BREAKING** Update imxrt-rs dependencies that affect the public API:
+
+- `imxrt-ral` 0.6
+- `iomxrt-iomuxc` 0.3
+
 **BREAKING** Remove deprecated APIs
 
 - `clko2::Selection::TracClk`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = { workspace = true }
 categories = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-version = "0.5.7"
+version = "0.6.0"
 
 [dependencies.cfg-if]
 version = "1.0"
@@ -106,14 +106,14 @@ members = ["board", "logging"]
 
 [workspace.dependencies]
 imxrt-dma = "0.1"
-imxrt-iomuxc = "0.2.1"
-imxrt-hal = { version = "0.5", path = "." }
+imxrt-iomuxc = "0.3.0"
+imxrt-hal = { version = "0.6", path = "." }
 imxrt-log = { path = "logging", default-features = false, features = [
     "log",
     "lpuart",
     "usbd",
 ] }
-imxrt-ral = "0.5"
+imxrt-ral = "0.6"
 imxrt-rt = "0.1"
 imxrt-usbd = "0.3"
 
@@ -204,3 +204,9 @@ name = "rtic_defmt_rtt"
 [[example]]
 name = "hal_i2c_lcd1602"
 required-features = ["board/lcd1602"]
+
+[patch.crates-io.imxrt-ral]
+git = "https://github.com/imxrt-rs/imxrt-ral"
+
+[patch.crates-io.imxrt-iomuxc]
+git = "https://github.com/imxrt-rs/imxrt-iomuxc"

--- a/logging/CHANGELOG.md
+++ b/logging/CHANGELOG.md
@@ -5,6 +5,7 @@
 **BREAKING** Integrate breaking dependencies for the USB back-end:
 
 - `imxrt-usbd` 0.3
+- `imxrt-hal` 0.6
 - `usb-device` 0.3
 - `usbd-serial` 0.2
 

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imxrt-log"
-version = "0.1.2"
+version = "0.2.0"
 edition = { workspace = true }
 description = "Logging extensions for i.MX RT processors."
 repository = { workspace = true }


### PR DESCRIPTION
Eagerly prepare for updates to our first-party dependencies:

- imxrt-rs/imxrt-ral#53
- imxrt-rs/imxrt-iomuxc#47

The patches effectively target those two PRs.