### PR TITLE
Remove LPSPI chip select type state, and other refactors

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -138,6 +138,24 @@ jobs:
     - name: Run unit, integration tests
       run: cargo test --features=${{ matrix.chips }} --features=defmt --tests --package=imxrt-hal --package=imxrt-log
 
+  # Make sure our unit tests can pass (some recent version of) miri.
+  miri:
+    needs: tests
+    strategy:
+      matrix:
+        chips:
+        - imxrt-ral/imxrt1011,imxrt1010
+        - imxrt-ral/imxrt1021,imxrt1020
+        - imxrt-ral/imxrt1062,imxrt1060
+        - imxrt-ral/imxrt1176_cm7,imxrt1170
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install a nightly toolchain with miri
+      run: rustup toolchain install nightly --no-self-update --profile minimal --component miri
+    - name: Run unit, integration tests with miri
+      run: cargo +nightly miri test --features=${{ matrix.chips }} --tests --package=imxrt-hal --package=imxrt-log --config "profile.dev.opt-level = 0"
+
   # Ensures that documentation builds, and that links are valid
   docs:
     needs: format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - There is no more `PCS0` type state associated with the LPSPI bus.
 
 Introduce a hardware chip select and SPI mode into each LPSPI transaction.
+Add an LPSPI configuration for hardware chip selects.
 
 **BREAKING** The following peripherals are not available on the 1180. Therefore,
 they are no longer considered common. However, their APIs are unchanged, and they

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - `LpspiError::{Busy, NoData}` are removed as possible LPSPI errors.
 - There is no more `PCS0` type state associated with the LPSPI bus.
+- `FifoStatus` has public members for TX and RX FIFO capacities.
 
 Introduce a hardware chip select and SPI mode into each LPSPI transaction.
 Add an LPSPI configuration for hardware chip selects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@
 - `timer::*PitChan`
 - `lpspi::Disabled::{set_mode, set_watermark}`
 
-**BREAKING** `LpspiError::{Busy, NoData}` are removed as possible LPSPI errors.
+**BREAKING** Change the LPSPI driver:
+
+- `LpspiError::{Busy, NoData}` are removed as possible LPSPI errors.
+- There is no more `PCS0` type state associated with the LPSPI bus.
 
 **BREAKING** The following peripherals are not available on the 1180. Therefore,
 they are no longer considered common. However, their APIs are unchanged, and they

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 - `LpspiError::{Busy, NoData}` are removed as possible LPSPI errors.
 - There is no more `PCS0` type state associated with the LPSPI bus.
 
+Introduce a hardware chip select into each LPSPI transaction.
+
 **BREAKING** The following peripherals are not available on the 1180. Therefore,
 they are no longer considered common. However, their APIs are unchanged, and they
 are still exposed when building with a chip feature.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - `LpspiError::{Busy, NoData}` are removed as possible LPSPI errors.
 - There is no more `PCS0` type state associated with the LPSPI bus.
 
-Introduce a hardware chip select into each LPSPI transaction.
+Introduce a hardware chip select and SPI mode into each LPSPI transaction.
 
 **BREAKING** The following peripherals are not available on the 1180. Therefore,
 they are no longer considered common. However, their APIs are unchanged, and they

--- a/board/src/imxrt1010evk.rs
+++ b/board/src/imxrt1010evk.rs
@@ -64,8 +64,10 @@ pub type SpiPins = hal::lpspi::Pins<
     iomuxc::gpio_ad::GPIO_AD_04, // SDO, J57_8
     iomuxc::gpio_ad::GPIO_AD_03, // SDI, J57_10
     iomuxc::gpio_ad::GPIO_AD_06, // SCK, J57_12
-    iomuxc::gpio_ad::GPIO_AD_05, // PCS0, J57_6
 >;
+
+/// SPI PCS0 (J57_6).
+pub type SpiPcs0 = iomuxc::gpio_ad::GPIO_AD_05;
 
 #[cfg(feature = "spi")]
 pub type Spi = hal::lpspi::Lpspi<SpiPins, 1>;
@@ -192,8 +194,11 @@ impl Specifics {
                 sdo: iomuxc.gpio_ad.p04,
                 sdi: iomuxc.gpio_ad.p03,
                 sck: iomuxc.gpio_ad.p06,
-                pcs0: iomuxc.gpio_ad.p05,
             };
+            crate::iomuxc::lpspi::prepare({
+                let pcs0: &mut SpiPcs0 = &mut iomuxc.gpio_ad.p05;
+                pcs0
+            });
             let mut spi = Spi::new(lpspi1, pins);
             spi.disabled(|spi| {
                 spi.set_clock_hz(super::LPSPI_CLK_FREQUENCY, super::SPI_BAUD_RATE_FREQUENCY);

--- a/board/src/imxrt1060evk.rs
+++ b/board/src/imxrt1060evk.rs
@@ -62,8 +62,9 @@ pub type SpiPins = hal::lpspi::Pins<
     iomuxc::gpio_sd_b0::GPIO_SD_B0_02, // SDO, J24_4
     iomuxc::gpio_sd_b0::GPIO_SD_B0_03, // SDI, J24_5
     iomuxc::gpio_sd_b0::GPIO_SD_B0_00, // SCK, J24_6
-    iomuxc::gpio_sd_b0::GPIO_SD_B0_01, // PCS0, J24_3
 >;
+/// SPI PCS0 (J24_3).
+pub type SpiPcs0 = iomuxc::gpio_sd_b0::GPIO_SD_B0_01;
 
 #[cfg(not(feature = "spi"))]
 /// Activate the `"spi"` feature to configure the SPI peripheral.
@@ -180,8 +181,11 @@ impl Specifics {
                 sdo: iomuxc.gpio_sd_b0.p02,
                 sdi: iomuxc.gpio_sd_b0.p03,
                 sck: iomuxc.gpio_sd_b0.p00,
-                pcs0: iomuxc.gpio_sd_b0.p01,
             };
+            crate::iomuxc::lpspi::prepare({
+                let pcs0: &mut SpiPcs0 = &mut iomuxc.gpio_sd_b0.p01;
+                pcs0
+            });
             let mut spi = Spi::new(lpspi1, pins);
             spi.disabled(|spi| {
                 spi.set_clock_hz(super::LPSPI_CLK_FREQUENCY, super::SPI_BAUD_RATE_FREQUENCY);

--- a/board/src/imxrt1170evk-cm7.rs
+++ b/board/src/imxrt1170evk-cm7.rs
@@ -92,8 +92,9 @@ pub type SpiPins = hal::lpspi::Pins<
     iomuxc::gpio_ad::GPIO_AD_30, // SDO, J10_8
     iomuxc::gpio_ad::GPIO_AD_31, // SDI, J10_10
     iomuxc::gpio_ad::GPIO_AD_28, // SCK, J10_12
-    iomuxc::gpio_ad::GPIO_AD_29, // PCS0, J10_6
 >;
+/// SPI PCS0 (J10_6).
+pub type SpiPcs0 = iomuxc::gpio_ad::GPIO_AD_29;
 const SPI_INSTANCE: u8 = 1;
 
 #[cfg(feature = "spi")]
@@ -207,8 +208,11 @@ impl Specifics {
                 sdo: iomuxc.gpio_ad.p30,
                 sdi: iomuxc.gpio_ad.p31,
                 sck: iomuxc.gpio_ad.p28,
-                pcs0: iomuxc.gpio_ad.p29,
             };
+            crate::iomuxc::lpspi::prepare({
+                let pcs0: &mut SpiPcs0 = &mut iomuxc.gpio_ad.p29;
+                pcs0
+            });
             let mut spi = Spi::new(lpspi1, pins);
             spi.disabled(|spi| {
                 spi.set_clock_hz(LPSPI_CLK_FREQUENCY, super::SPI_BAUD_RATE_FREQUENCY);

--- a/board/src/teensy4.rs
+++ b/board/src/teensy4.rs
@@ -49,8 +49,10 @@ pub type SpiPins = hal::lpspi::Pins<
     iomuxc::gpio_b0::GPIO_B0_02, // SDO, P11
     iomuxc::gpio_b0::GPIO_B0_01, // SDI, P12
     iomuxc::gpio_b0::GPIO_B0_03, // SCK, P13
-    iomuxc::gpio_b0::GPIO_B0_00, // PCS0, P10
 >;
+
+/// SPI PCS0 (P10).
+pub type SpiPcs0 = iomuxc::gpio_b0::GPIO_B0_00;
 
 #[cfg(not(feature = "spi"))]
 /// Activate the `"spi"` feature to configure the SPI peripheral.
@@ -152,8 +154,11 @@ impl Specifics {
                 sdo: iomuxc.gpio_b0.p02,
                 sdi: iomuxc.gpio_b0.p01,
                 sck: iomuxc.gpio_b0.p03,
-                pcs0: iomuxc.gpio_b0.p00,
             };
+            crate::iomuxc::lpspi::prepare({
+                let pcs0: &mut SpiPcs0 = &mut iomuxc.gpio_b0.p00;
+                pcs0
+            });
             let mut spi = Spi::new(lpspi4, pins);
             spi.disabled(|spi| {
                 spi.set_clock_hz(super::LPSPI_CLK_FREQUENCY, super::SPI_BAUD_RATE_FREQUENCY);

--- a/src/chip/drivers/dma.rs
+++ b/src/chip/drivers/dma.rs
@@ -196,10 +196,9 @@ impl<P, const N: u8> lpspi::Lpspi<P, N> {
         channel: &'a mut Channel,
         buffer: &'a [u32],
     ) -> Result<peripheral::Write<'a, Self, u32>, lpspi::LpspiError> {
-        let mut transaction = lpspi::Transaction::new_u32s(buffer)?;
-        transaction.bit_order = self.bit_order();
-
+        let mut transaction = self.bus_transaction(buffer)?;
         transaction.receive_data_mask = true;
+
         self.wait_for_transmit_fifo_space()?;
         self.enqueue_transaction(&transaction);
         Ok(peripheral::write(channel, buffer, self))
@@ -216,10 +215,9 @@ impl<P, const N: u8> lpspi::Lpspi<P, N> {
         channel: &'a mut Channel,
         buffer: &'a mut [u32],
     ) -> Result<peripheral::Read<'a, Self, u32>, lpspi::LpspiError> {
-        let mut transaction = lpspi::Transaction::new_u32s(buffer)?;
-        transaction.bit_order = self.bit_order();
-
+        let mut transaction = self.bus_transaction(buffer)?;
         transaction.transmit_data_mask = true;
+
         self.wait_for_transmit_fifo_space()?;
         self.enqueue_transaction(&transaction);
         Ok(peripheral::read(channel, self, buffer))
@@ -238,8 +236,7 @@ impl<P, const N: u8> lpspi::Lpspi<P, N> {
         tx: &'a mut Channel,
         buffer: &'a mut [u32],
     ) -> Result<peripheral::FullDuplex<'a, Self, u32>, lpspi::LpspiError> {
-        let mut transaction = lpspi::Transaction::new_u32s(buffer)?;
-        transaction.bit_order = self.bit_order();
+        let transaction = self.bus_transaction(buffer)?;
 
         self.wait_for_transmit_fifo_space()?;
         self.enqueue_transaction(&transaction);

--- a/src/common/lpspi.rs
+++ b/src/common/lpspi.rs
@@ -48,7 +48,6 @@
 //!     sdo: pads.gpio_b0.p02,
 //!     sdi: pads.gpio_b0.p01,
 //!     sck: pads.gpio_b0.p03,
-//!     pcs0: pads.gpio_b0.p00,
 //! };
 //!
 //! let mut spi4 = unsafe { LPSPI4::instance() };
@@ -403,13 +402,12 @@ pub struct Lpspi<P, const N: u8> {
 ///     GPIO_B0_02,
 ///     GPIO_B0_01,
 ///     GPIO_B0_03,
-///     GPIO_B0_00,
 /// >;
 ///
 /// // Helper type for your SPI peripheral
 /// type Lpspi<const N: u8> = hal::lpspi::Lpspi<LpspiPins, N>;
 /// ```
-pub struct Pins<SDO, SDI, SCK, PCS0> {
+pub struct Pins<SDO, SDI, SCK> {
     /// Serial data out
     ///
     /// Data travels from the SPI host controller to the SPI device.
@@ -420,29 +418,23 @@ pub struct Pins<SDO, SDI, SCK, PCS0> {
     pub sdi: SDI,
     /// Serial clock
     pub sck: SCK,
-    /// Chip select 0
-    ///
-    /// (PCSx) convention matches the hardware.
-    pub pcs0: PCS0,
 }
 
-impl<SDO, SDI, SCK, PCS0, const N: u8> Lpspi<Pins<SDO, SDI, SCK, PCS0>, N>
+impl<SDO, SDI, SCK, const N: u8> Lpspi<Pins<SDO, SDI, SCK>, N>
 where
     SDO: lpspi::Pin<Module = consts::Const<N>, Signal = lpspi::Sdo>,
     SDI: lpspi::Pin<Module = consts::Const<N>, Signal = lpspi::Sdi>,
     SCK: lpspi::Pin<Module = consts::Const<N>, Signal = lpspi::Sck>,
-    PCS0: lpspi::Pin<Module = consts::Const<N>, Signal = lpspi::Pcs0>,
 {
     /// Create a new LPSPI driver from the RAL LPSPI instance and a set of pins.
     ///
     /// When this call returns, the LPSPI pins are configured for their function.
     /// The peripheral is enabled after reset. The LPSPI clock speed is unspecified.
     /// The mode is [`MODE_0`]. The sample point is [`SamplePoint::DelayedEdge`].
-    pub fn new(lpspi: ral::lpspi::Instance<N>, mut pins: Pins<SDO, SDI, SCK, PCS0>) -> Self {
+    pub fn new(lpspi: ral::lpspi::Instance<N>, mut pins: Pins<SDO, SDI, SCK>) -> Self {
         lpspi::prepare(&mut pins.sdo);
         lpspi::prepare(&mut pins.sdi);
         lpspi::prepare(&mut pins.sck);
-        lpspi::prepare(&mut pins.pcs0);
         Self::init(lpspi, pins)
     }
 }

--- a/src/common/lpspi.rs
+++ b/src/common/lpspi.rs
@@ -810,8 +810,7 @@ impl<P, const N: u8> Lpspi<P, N> {
             return Ok(());
         }
 
-        let mut transaction = Transaction::new_words(data)?;
-        transaction.bit_order = self.bit_order();
+        let transaction = self.bus_transaction(data)?;
 
         self.wait_for_transmit_fifo_space()?;
         self.enqueue_transaction(&transaction);
@@ -835,9 +834,8 @@ impl<P, const N: u8> Lpspi<P, N> {
             return Ok(());
         }
 
-        let mut transaction = Transaction::new_words(data)?;
+        let mut transaction = self.bus_transaction(data)?;
         transaction.receive_data_mask = true;
-        transaction.bit_order = self.bit_order();
 
         self.wait_for_transmit_fifo_space()?;
         self.enqueue_transaction(&transaction);
@@ -991,6 +989,13 @@ impl<P, const N: u8> Lpspi<P, N> {
             dbt: dbt as u8,
             sckdiv: sckdiv as u8,
         }
+    }
+
+    /// Produce a transaction that considers bus-managed software state.
+    pub(crate) fn bus_transaction<W>(&self, words: &[W]) -> Result<Transaction, LpspiError> {
+        let mut transaction = Transaction::new_words(words)?;
+        transaction.bit_order = self.bit_order();
+        Ok(transaction)
     }
 }
 

--- a/src/common/lpspi.rs
+++ b/src/common/lpspi.rs
@@ -363,7 +363,7 @@ impl Transaction {
 /// Sets the clock speed parameters.
 ///
 /// This should only happen when the LPSPI peripheral is disabled.
-fn set_spi_clock(source_clock_hz: u32, spi_clock_hz: u32, reg: &ral::lpspi::RegisterBlock) {
+fn compute_spi_clock(source_clock_hz: u32, spi_clock_hz: u32) -> ClockConfigs {
     // Round up, so we always get a resulting SPI clock that is
     // equal or less than the requested frequency.
     let half_div =
@@ -376,16 +376,16 @@ fn set_spi_clock(source_clock_hz: u32, spi_clock_hz: u32, reg: &ral::lpspi::Regi
     // Because half_div is in range [3,128], sckdiv is in range [4, 254].
     let sckdiv = 2 * (half_div - 1);
 
-    ral::write_reg!(ral::lpspi, reg, CCR,
+    ClockConfigs {
         // Delay between two clock transitions of two consecutive transfers
         // is exactly sckdiv/2, which causes the transfer to be seamless.
-        DBT: half_div - 1,
+        dbt: (half_div - 1) as u8,
         // Add one sckdiv/2 setup and hold time before and after the transfer,
         // to make sure the signal is stable at sample time
-        PCSSCK: half_div - 1,
-        SCKPCS: half_div - 1,
-        SCKDIV: sckdiv
-    );
+        pcssck: (half_div - 1) as u8,
+        sckpcs: (half_div - 1) as u8,
+        sckdiv: sckdiv as u8,
+    }
 }
 
 /// LPSPI clock configurations.
@@ -420,6 +420,47 @@ pub struct ClockConfigs {
     pub sckdiv: u8,
 }
 
+impl ClockConfigs {
+    const fn as_raw(self) -> u32 {
+        use ral::lpspi::CCR;
+        (self.sckpcs as u32) << CCR::SCKPCS::offset
+            | (self.pcssck as u32) << CCR::PCSSCK::offset
+            | (self.dbt as u32) << CCR::DBT::offset
+            | (self.sckdiv as u32) << CCR::SCKDIV::offset
+    }
+}
+
+/// In-memory clock configuration register values.
+///
+/// Newer LPSPI IP blocks, like those found on the 1180, have `CCR[DBT]`
+/// and `CCR[SCKDIV]` fields that are WO/RAZ. RAZ is incompatible
+/// with older IP blocks, like those found on all the other MCUs.
+///
+/// If we cache these values, all RMW on CCR will behave as if we
+/// read those values through the register.
+struct CcrCache {
+    dbt: u8,
+    sckdiv: u8,
+}
+
+impl CcrCache {
+    /// Reac the clock configuration values, considering the cached values.
+    fn read_ccr(&self, lpspi: &ral::lpspi::RegisterBlock) -> ClockConfigs {
+        let (sckpcs, pcssck) = ral::read_reg!(ral::lpspi, lpspi, CCR, SCKPCS, PCSSCK);
+        ClockConfigs {
+            sckpcs: sckpcs as u8,
+            pcssck: pcssck as u8,
+            dbt: self.dbt,
+            sckdiv: self.sckdiv,
+        }
+    }
+    /// Update the cached values.
+    fn update(&mut self, clock_configs: ClockConfigs) {
+        self.dbt = clock_configs.dbt;
+        self.sckdiv = clock_configs.sckdiv;
+    }
+}
+
 /// An LPSPI driver.
 ///
 /// The driver exposes low-level methods for coordinating
@@ -436,6 +477,7 @@ pub struct Lpspi<P, const N: u8> {
     pins: P,
     bit_order: BitOrder,
     mode: Mode,
+    ccr_cache: CcrCache,
 }
 
 /// Pins for a LPSPI device.
@@ -509,6 +551,8 @@ impl<P, const N: u8> Lpspi<P, N> {
             pins,
             bit_order: BitOrder::default(),
             mode: MODE_0,
+            // Once we issue a reset, below, these are zero.
+            ccr_cache: CcrCache { dbt: 0, sckdiv: 0 },
         };
 
         // Reset and disable
@@ -597,7 +641,7 @@ impl<P, const N: u8> Lpspi<P, N> {
     /// The handle to a [`Disabled`](crate::lpspi::Disabled) driver lets you modify
     /// LPSPI settings that require a fully disabled peripheral.
     pub fn disabled<R>(&mut self, func: impl FnOnce(&mut Disabled<N>) -> R) -> R {
-        let mut disabled = Disabled::new(&mut self.lpspi);
+        let mut disabled = Disabled::new(&mut self.lpspi, &mut self.ccr_cache);
         func(&mut disabled)
     }
 
@@ -949,7 +993,7 @@ impl<P, const N: u8> Lpspi<P, N> {
         let cfgr1 = ral::read_reg!(ral::lpspi, self.lpspi, CFGR1);
         let dmr0 = ral::read_reg!(ral::lpspi, self.lpspi, DMR0);
         let dmr1 = ral::read_reg!(ral::lpspi, self.lpspi, DMR1);
-        let ccr = ral::read_reg!(ral::lpspi, self.lpspi, CCR);
+        let ccr = self.clock_configs().as_raw();
         let fcr = ral::read_reg!(ral::lpspi, self.lpspi, FCR);
 
         // Backup enabled state
@@ -1006,14 +1050,7 @@ impl<P, const N: u8> Lpspi<P, N> {
     /// These values are decided by calls to [`set_clock_hz`](Disabled::set_clock_hz)
     /// and [`set_clock_configs`](Disabled::set_clock_configs).
     pub fn clock_configs(&self) -> ClockConfigs {
-        let (sckpcs, pcssck, dbt, sckdiv) =
-            ral::read_reg!(ral::lpspi, self.lpspi, CCR, SCKPCS, PCSSCK, DBT, SCKDIV);
-        ClockConfigs {
-            sckpcs: sckpcs as u8,
-            pcssck: pcssck as u8,
-            dbt: dbt as u8,
-            sckdiv: sckdiv as u8,
-        }
+        self.ccr_cache.read_ccr(&self.lpspi)
     }
 
     /// Produce a transaction that considers bus-managed software state.
@@ -1180,10 +1217,11 @@ fn set_watermark(lpspi: &ral::lpspi::RegisterBlock, direction: Direction, waterm
 pub struct Disabled<'a, const N: u8> {
     lpspi: &'a ral::lpspi::Instance<N>,
     men: bool,
+    ccr_cache: &'a mut CcrCache,
 }
 
 impl<'a, const N: u8> Disabled<'a, N> {
-    fn new(lpspi: &'a mut ral::lpspi::Instance<N>) -> Self {
+    fn new(lpspi: &'a mut ral::lpspi::Instance<N>, ccr_cache: &'a mut CcrCache) -> Self {
         let men = ral::read_reg!(ral::lpspi, lpspi, CR, MEN == MEN_1);
 
         // Request disable
@@ -1191,7 +1229,11 @@ impl<'a, const N: u8> Disabled<'a, N> {
         // Wait for the driver to finish its current transfer
         // and enter disabled state
         while ral::read_reg!(ral::lpspi, lpspi, CR, MEN == MEN_1) {}
-        Self { lpspi, men }
+        Self {
+            lpspi,
+            men,
+            ccr_cache,
+        }
     }
 
     /// Set the LPSPI clock speed (Hz).
@@ -1199,7 +1241,8 @@ impl<'a, const N: u8> Disabled<'a, N> {
     /// `source_clock_hz` is the LPSPI peripheral clock speed. To specify the
     /// peripheral clock, see the [`ccm::lpspi_clk`](crate::ccm::lpspi_clk) documentation.
     pub fn set_clock_hz(&mut self, source_clock_hz: u32, clock_hz: u32) {
-        set_spi_clock(source_clock_hz, clock_hz, self.lpspi);
+        let clock_configs = compute_spi_clock(source_clock_hz, clock_hz);
+        self.set_clock_configs(clock_configs);
     }
 
     /// Set LPSPI timing configurations.
@@ -1207,6 +1250,7 @@ impl<'a, const N: u8> Disabled<'a, N> {
     /// If you're not sure how to select these timing values, prefer
     /// [`set_clock_hz`](Self::set_clock_hz).
     pub fn set_clock_configs(&mut self, timing: ClockConfigs) {
+        self.ccr_cache.update(timing);
         ral::write_reg!(ral::lpspi, self.lpspi, CCR,
             SCKPCS: timing.sckpcs as u32,
             PCSSCK: timing.pcssck as u32,

--- a/src/common/lpspi.rs
+++ b/src/common/lpspi.rs
@@ -265,6 +265,10 @@ pub struct Transaction {
     /// `Transaction`, one that had [`continuous`](Self::continuous) set.
     /// The default value is `false`.
     pub continuing: bool,
+    /// The SPI mode for the transaction.
+    ///
+    /// By default, this is [`MODE_0`].
+    pub mode: Mode,
     /// Selects the hardware-managed peripheral chip select for the transaction.
     ///
     /// See [`Pcs`] for more information.
@@ -327,6 +331,7 @@ impl Transaction {
                 frame_size: frame_size - 1,
                 continuing: false,
                 continuous: false,
+                mode: MODE_0,
                 pcs: Default::default(),
             })
         } else {
@@ -756,10 +761,10 @@ impl<P, const N: u8> Lpspi<P, N> {
     ///
     /// You're responsible for making sure there's space in the transmit
     /// FIFO for this transaction command.
-    pub fn enqueue_transaction(&mut self, transaction: &Transaction) {
+    pub fn enqueue_transaction(&self, transaction: &Transaction) {
         ral::write_reg!(ral::lpspi, self.lpspi, TCR,
-            CPOL: if self.mode.polarity == Polarity::IdleHigh { CPOL_1 } else { CPOL_0 },
-            CPHA: if self.mode.phase == Phase::CaptureOnSecondTransition { CPHA_1 } else { CPHA_0 },
+            CPOL: if transaction.mode.polarity == Polarity::IdleHigh { CPOL_1 } else { CPOL_0 },
+            CPHA: if transaction.mode.phase == Phase::CaptureOnSecondTransition { CPHA_1 } else { CPHA_0 },
             PRESCALE: PRESCALE_0,
             PCS: PCS_0,
             WIDTH: WIDTH_0,
@@ -995,6 +1000,7 @@ impl<P, const N: u8> Lpspi<P, N> {
     pub(crate) fn bus_transaction<W>(&self, words: &[W]) -> Result<Transaction, LpspiError> {
         let mut transaction = Transaction::new_words(words)?;
         transaction.bit_order = self.bit_order();
+        transaction.mode = self.mode;
         Ok(transaction)
     }
 }

--- a/src/common/lpspi.rs
+++ b/src/common/lpspi.rs
@@ -156,6 +156,26 @@ pub enum Pcs {
     Pcs3,
 }
 
+/// The hardware chip select polarity.
+///
+/// Use [`Disabled::set_chip_select_polarity`] to configure
+/// each chip select's polarity. Consult your peripheral's
+/// documentation to understand which polarity is expected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[repr(u32)]
+pub enum PcsPolarity {
+    /// The chip select is active low.
+    ///
+    /// When idle, the chip select is high. This is
+    /// the default state.
+    #[default]
+    ActiveLow,
+    /// The chip select is active high.
+    ///
+    /// When idle, the chip select is low.
+    ActiveHigh,
+}
+
 /// An LPSPI transaction definition.
 ///
 /// The transaction defines how many bits the driver sends or recieves.
@@ -1218,6 +1238,21 @@ impl<'a, const N: u8> Disabled<'a, N> {
     #[inline]
     pub fn set_peripheral_enable(&mut self, enable: bool) {
         ral::modify_reg!(ral::lpspi, self.lpspi, CFGR1, MASTER: !enable as u32);
+    }
+
+    /// Set the polarity for the `pcs` hardware chip select.
+    ///
+    /// By default, all polarities are active low.
+    #[inline]
+    pub fn set_chip_select_polarity(&mut self, pcs: Pcs, polarity: PcsPolarity) {
+        let pcspol = ral::read_reg!(ral::lpspi, self.lpspi, CFGR1, PCSPOL);
+        let mask = 1 << pcs as u32;
+        let pcspol = if polarity == PcsPolarity::ActiveHigh {
+            pcspol | mask
+        } else {
+            pcspol & !mask
+        };
+        ral::modify_reg!(ral::lpspi, self.lpspi, CFGR1, PCSPOL: pcspol);
     }
 }
 


### PR DESCRIPTION
Most of these commits support a larger change that implements embedded-hal `SpiBus` and `SpiDevice` (#181). They also anticipate support for the 1180. See commit messages for details.

Although some of these may be backwards compatible, I'm not immediately back-porting them onto v0.5. Let me know if something seems useful.

Closes #131, since it provides a way to select and change the LPSPI hardware chip select. Also closes #149; this PR has a similar breaking change.