### PR TITLE
Remove IOMUXC_GPR writes in SAI driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ types can be formatted with `defmt`.
 
 Export the SAI driver for 1170 MCUs.
 
+The SAI driver would overwrite other configurations in an IOMUXC\_GPR register,
+and it would fail to configure clock directions for SAI instances other than
+SAI1. This release removes this IOMUXC\_GPR interaction. Users should directly
+use the IOMUXC\_GPR to configure their own clocks.
+
 ## [0.5.10] 2025-06-14
 
 Add SAI driver, supporting audio transmit, for 1000 series MCUs. 1170 support

--- a/board/src/imxrt1010evk.rs
+++ b/board/src/imxrt1010evk.rs
@@ -177,6 +177,9 @@ impl Specifics {
         let mut iomuxc = super::convert_iomuxc(iomuxc);
         configure_pins(&mut iomuxc);
 
+        let iomuxc_gpr = unsafe { ral::iomuxc_gpr::IOMUXC_GPR::instance() };
+        ral::modify_reg!(ral::iomuxc_gpr, iomuxc_gpr, GPR1, SAI1_MCLK_DIR: 1);
+
         let gpio1 = unsafe { ral::gpio::GPIO1::instance() };
         let mut gpio1 = hal::gpio::Port::new(gpio1);
         let gpio2 = unsafe { ral::gpio::GPIO2::instance() };

--- a/board/src/teensy4.rs
+++ b/board/src/teensy4.rs
@@ -141,6 +141,9 @@ impl Specifics {
         let mut iomuxc = super::convert_iomuxc(iomuxc);
         configure_pins(&mut iomuxc);
 
+        let iomuxc_gpr = unsafe { ral::iomuxc_gpr::IOMUXC_GPR::instance() };
+        ral::modify_reg!(ral::iomuxc_gpr, iomuxc_gpr, GPR1, SAI1_MCLK_DIR: 1);
+
         let gpio1 = unsafe { ral::gpio::GPIO1::instance() };
         let mut gpio1 = hal::gpio::Port::new(gpio1);
 

--- a/src/chip/drivers/sai.rs
+++ b/src/chip/drivers/sai.rs
@@ -14,6 +14,11 @@
 //!
 //! The configuration of the SAI is encoded in configuration structure that can be used with a singular
 //! configure method.
+//!
+//! ## Clock configuration
+//!
+//! Make sure to configure your clocks before using the audio interface. Note that there may be
+//! additional clock settings in `IOMUXC_GPR`.
 
 use crate::iomuxc::{consts, sai};
 use crate::ral;
@@ -678,14 +683,6 @@ impl<const N: u8, Mclk, TxPins, RxPins> Sai<N, Mclk, TxPins, RxPins> {
         Option<Tx<N, WORD_SIZE, FRAME_SIZE, PACKING>>,
         Option<Rx<N, WORD_SIZE, FRAME_SIZE, PACKING>>,
     ) {
-        // Safety: set the mclk pin to be an output
-        unsafe {
-            #[cfg(chip = "imxrt1170")]
-            ral::write_reg!(ral::iomuxc_gpr, ral::iomuxc_gpr::IOMUXC_GPR::instance(), GPR0, SAI1_MCLK_DIR: 1);
-            #[cfg(not(chip = "imxrt1170"))]
-            ral::write_reg!(ral::iomuxc_gpr, ral::iomuxc_gpr::IOMUXC_GPR::instance(), GPR1, SAI1_MCLK_DIR: 1);
-        }
-
         let tx = self.tx_pins.map(|_| Tx {
             // Safety: create instance
             sai: unsafe { ral::sai::Instance::<N>::new(&*self.sai) },


### PR DESCRIPTION
This came up in the first review, but it was missed in subsequent reviews. See the changelog for more information.

Users can configure their clocks themselves. I'm treating this as a driver bug, and I'll release an updated driver in the 0.5 series.